### PR TITLE
Fix for compilation problem and a segmentation faults on Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,25 @@ MANDOC_COMPRESSED=rmlint.1.gz
 
 #install
 INSTALLPATH=$(DESTDIR)/usr/bin
+UNAME := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 
 #Programs 
 ECHO=echo
 RM=rm -rf
 CAT=cat
 CP=cp
-STRIP=strip -s
+
+ifeq ($(UNAME),Darwin)
+	STRIP=strip
+	OPTI=-O4
+	CC?=clang
+else
+	STRIP=strip -s
+	OPTI=-march=native -O3 -finline-functions
+	CC?=gcc
+endif
+
+
 MKDIR=mkdir -p
 GZIP=gzip -c -f
 
@@ -25,8 +37,6 @@ CC?=gcc
 
 #Heavy Warnlevel 
 WARN=-Wall -pedantic
-
-OPTI=-march=native -O3 -finline-functions
 
 #Link flags 
 LDFLAGS+=-lpthread -lm

--- a/src/filter.c
+++ b/src/filter.c
@@ -27,6 +27,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <libgen.h>
+#include <alloca.h>
 
 #include <ftw.h>
 #include <signal.h>


### PR DESCRIPTION
Two minor changes to enable compilation and fix a segmentation fault on Mac OS X:
- `strip -s` doesn't work on Mac OS X so we just use strip by itself
- The default compiler and flags lead to a segmentation fault, using `clang` and these flags allow it to work properly. 
