### PR TITLE
Improvements to README code and link to rmlint-git AUR package

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -34,7 +34,7 @@ bc. cd <name_of_the_dir>
 make -j 2  && sudo make install
 
 <h4>Packages</h4>
-A PKGBUILD is available in the AUR.
+A PKGBUILD is available in the AUR: "@rmlint-git@":https://aur.archlinux.org/packages/rmlint-git/
 
 <h2>HELP:</h2>
 <h4>Use:</h4>


### PR DESCRIPTION
Further to #37:
1. Code is formatted to avoid “, ” and — appearing instead of copy-paste-able characters.
2. A link to the rmlint-git AUR package is added so people know how to grab the maintained version.
