### PR TITLE
New way of specifying lint types to search for:

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -115,7 +115,7 @@ typedef enum RmLintType {
     /* Border */
     RM_LINT_TYPE_OTHER_LINT,
     /* note: this needs to be last item in list */
-    RM_LINT_TYPE_DUPE_CANDIDATE 
+    RM_LINT_TYPE_DUPE_CANDIDATE
 } RmLintType;
 
 typedef enum RmHandleMode {
@@ -137,6 +137,7 @@ typedef struct RmSettings {
     char paranoid;
     char namecluster;
     char findbadids;
+    char findbadlinks;
     char searchdup;
     char findemptydirs;
     char nonstripped;

--- a/src/traverse.c
+++ b/src/traverse.c
@@ -288,8 +288,9 @@ void traverse_path(gpointer data, gpointer userdata) {
                 case FTS_INIT:      /* initialized only */
                     break;
                 case FTS_SLNONE:    /* symbolic link without target */
-                    warning(RED"Warning: symlink without target: %s\n"NCO, p->fts_path);
-                    numfiles += process_file(traverse_session, p->fts_statp, p->fts_path, is_ppath, pnum, RM_LINT_TYPE_BLNK);
+                    if (settings->findbadlinks) {
+                        numfiles += process_file(traverse_session, p->fts_statp, p->fts_path, is_ppath, pnum, RM_LINT_TYPE_BLNK);
+                    }
                     clear_emptydir_flags = true; /*current dir not empty*/
                     break;
                 case FTS_W:         /* whiteout object */


### PR DESCRIPTION
--types [+-]types
valid types:
  all
  none
  default[s]
  emptyd[irs] / ed
  emptyf[iles] / ef
  bad[ids] / bi
  nons[tripped] / ns
  name[clusters] / nc
  duplicates / du[pes] / df
