### PR TITLE
Fix duplicate messages definitions (fatal errors with msginit)

### DIFF
--- a/po/rmlint.pot
+++ b/po/rmlint.pot
@@ -358,12 +358,3 @@ msgstr ""
 #, c-format
 msgid "'%s': fts_read failed on %s"
 msgstr ""
-
-#: src/utilities.c:166
-#, c-format
-msgid "cannot open file '%s' for nonstripped test: "
-msgstr ""
-
-#: src/utilities.c:173
-msgid "ELF Library is out of date!"
-msgstr ""


### PR DESCRIPTION
msginit -i po/rmlint.pot -o po/fr.po --locale fr --no-translator
po/rmlint.pot:364: Double définition de message...
po/rmlint.pot:33: ...voici l'endroit de la première occurence
po/rmlint.pot:368: Double définition de message...
po/rmlint.pot:37: ...voici l'endroit de la première occurence
msginit: 2 erreurs fatales trouvées
