### PR TITLE
Updated the way environment is forwarded to scons.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -404,11 +404,10 @@ options = dict(
     SHLINKCOMSTR=link_shared_library_message,
     LINKCOMSTR=link_program_message,
     PREFIX=GetOption('prefix'),
-    ENV={
-        'PATH': os.environ['PATH'],
-        'TERM': os.environ['TERM'],
-        'HOME': os.environ['HOME']
-    }
+    ENV = dict([ (key, os.environ[key])
+                 for key in os.environ
+                 if key in ['PATH', 'TERM', 'HOME', 'PKG_CONFIG_PATH']
+              ])
 )
 
 if ARGUMENTS.get('VERBOSE') == "1":


### PR DESCRIPTION
- Do not raise an error if an environment variable isn't defined (notably: `TERM` should be optional).
- Forward the `PKG_CONFIG_PATH` variable, used by `pkg-config`.

Rationale: I'm packaging `rmlint` for [nix](https://github.com/NixOS/nixpkgs).