### PR TITLE
lib: Fix typo in with_color assignment

### DIFF
--- a/lib/cmdline.c
+++ b/lib/cmdline.c
@@ -1217,7 +1217,7 @@ bool rm_cmd_parse_args(int argc, char **argv, RmSession *session) {
     if(cfg->with_color) {
         cfg->with_stdout_color = isatty(fileno(stdout));
         cfg->with_stderr_color = isatty(fileno(stdout));
-        cfg->with_color = (cfg->with_stderr_color | cfg->with_stderr_color);
+        cfg->with_color = (cfg->with_stdout_color | cfg->with_stderr_color);
     } else {
         cfg->with_stdout_color = cfg->with_stderr_color = 0;
     }


### PR DESCRIPTION
I suppose with_color should have non-zero value if with_stdout_color or
with_stderr_color is non-zero. Former one was not used due to typo.

Issue detected by Cppcheck:

    [lib/cmdline.c:1220] -> [lib/cmdline.c:1220]: (style) Same expression on both sides of '|'.