### PR TITLE
Cleanup/checksum buffer mem

### DIFF
--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -82,9 +82,8 @@ Before saying that the paranoid mode of ``rmlint`` is a memory hog, it should be
 noted (since this can't be seen on those plots) that the memory consumption
 scales very well. Partly because ``rmlint`` saves all paths in a Trie_, making
 it usable for :math:`\geq` `5M files`_. Also it is able to control the amount of
-memory it uses in the paranoid mode (``--max-paranoid-mem``). Due to the high
-amount of internal data structures it however has a rather large base memory
-footprint.
+memory it uses (``--limit-mem``). Due to the high amount of internal data
+structures it however has a rather large base memory footprint.
 
 ``dupd`` uses direct file comparison for groups of two and three files and hash
 functions for the rest. It seems to have a rather high memory footprint in any

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -276,4 +276,4 @@ Insane ones
   (find matches using hashes then confirm via bytewise comparison).  Each file is
   read once only.  This achieves bytewise comparison in O(N) time, even if there are
   large clusters of same-size files.  The downside is that it is somewhat memory-intensive
-  (can be configured by ``--max-paranoid-mem`` option).
+  (can be configured by ``--limit-mem`` option).

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -65,9 +65,7 @@ void rm_cfg_set_default(RmCfg *cfg) {
     cfg->verbosity = G_LOG_LEVEL_INFO;
     cfg->follow_symlinks = false;
 
-    cfg->read_buffer_mem = 16 * 1024 * 1024;
-    cfg->paranoid_mem = 256 * 1024 * 1024;
-    cfg->total_mem = (RmOff)2 * 1024 * 1024 * 1024;
+    cfg->total_mem = (RmOff) 1024 * 1024 * 1024;
     cfg->sweep_size = 1024 * 1024 * 1024;
     cfg->sweep_count = 1024 * 16;
 

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -100,12 +100,6 @@ typedef struct RmCfg {
     guint threads_per_disk;
     RmDigestType checksum_type;
 
-    /* number of bytes to allocate to reading buffer during shredding */
-    RmOff read_buffer_mem;
-
-    /* number of bytes to allocate to in-progress paranoid digests */
-    RmOff paranoid_mem;
-
     /* total number of bytes we are allowed to use (target only) */
     RmOff total_mem;
 

--- a/lib/checksum.c
+++ b/lib/checksum.c
@@ -89,7 +89,7 @@ RmBuffer *rm_buffer_get(RmBufferPool *pool) {
     g_mutex_lock(&pool->lock);
     {
         while(!buffer) {
-            buffer = rm_util_slist_pop(&pool->stack);
+            buffer = rm_util_slist_pop(&pool->stack, NULL);
             if (!buffer && pool->avail_buffers > 0) {
                 buffer = rm_buffer_new(pool);
             }

--- a/lib/checksum.c
+++ b/lib/checksum.c
@@ -753,7 +753,6 @@ gboolean rm_digest_equal(RmDigest *a, RmDigest *b) {
         /* check if already rejected */
         if(g_slist_find(a->paranoid->rejects, b) ||
            g_slist_find(b->paranoid->rejects, a)) {
-            // rm_log_error_line("Optimisation sufficiently optimised");
             return false;
         }
         /* all the "easy" ways failed... do manual check of all buffers */

--- a/lib/checksum.h
+++ b/lib/checksum.h
@@ -301,21 +301,18 @@ RmOff rm_buffer_size(RmBufferPool *pool);
  * A buffer pool holds a number of same-sized RmBuffer structs
  * up to a maximum number of bytes.
  *
- * If the limit is hit, rm_buffer_pool_get() will block till
+ * If the limit is hit, rm_buffer_get() will block till
  * other buffers were released.
  *
  * @param buffer_size The size of each buffer.
- * @param max_mem Maxmimum number of bytes the pool may allocate.
- * @param max_kept_mem Maximum number of bytes the pool may cache.
+ * @param max_mem Maxmimum number of bytes the pool may allocate; 0 for no limit.
  *
  * @return A readily usable RmBufferPool.
  */
-RmBufferPool *rm_buffer_pool_init(gsize buffer_size, gsize max_mem, gsize max_kept_mem);
+RmBufferPool *rm_buffer_pool_init(gsize buffer_size, gsize max_mem);
 
 /**
  * @brief Destroy a RmBufferPool.
- *
- * This will wait for the currently pending action to finish.
  *
  * This can only be safely called when no parallel access to the pool is done.
  */
@@ -326,14 +323,14 @@ void rm_buffer_pool_destroy(RmBufferPool *pool);
  *
  * This might be either a previsouly used one or initially allocate one.
  */
-RmBuffer *rm_buffer_pool_get(RmBufferPool *pool);
+RmBuffer *rm_buffer_get(RmBufferPool *pool);
 
 /**
  * @brief Release a previosuly retrieved buffer.
  *
  * It will be either cached or freed if over the limit.
  */
-void rm_buffer_pool_release(RmBuffer *buf);
+void rm_buffer_release(RmBuffer *buf);
 
 /**
  * @brief Send a new (pending) paranoid digest match `candidate` for `target`.

--- a/lib/cmdline.c
+++ b/lib/cmdline.c
@@ -901,18 +901,6 @@ static gboolean rm_cmd_parse_limit_mem(_U const char *option_name, const gchar *
     return (rm_cmd_parse_mem(size_spec, error, &session->cfg->total_mem));
 }
 
-static gboolean rm_cmd_parse_paranoid_mem(_U const char *option_name,
-                                          const gchar *size_spec, RmSession *session,
-                                          GError **error) {
-    return (rm_cmd_parse_mem(size_spec, error, &session->cfg->paranoid_mem));
-}
-
-static gboolean rm_cmd_parse_read_buffer_mem(_U const char *option_name,
-                                             const gchar *size_spec, RmSession *session,
-                                             GError **error) {
-    return (rm_cmd_parse_mem(size_spec, error, &session->cfg->read_buffer_mem));
-}
-
 static gboolean rm_cmd_parse_sweep_size(_U const char *option_name,
                                         const gchar *size_spec, RmSession *session,
                                         GError **error) {
@@ -1345,8 +1333,6 @@ bool rm_cmd_parse_args(int argc, char **argv, RmSession *session) {
         {"clamp-low"              , 'q' , HIDDEN           , G_OPTION_ARG_CALLBACK , FUNC(clamp_low)              , "Limit lower reading barrier"                                 , "P"}    ,
         {"clamp-top"              , 'Q' , HIDDEN           , G_OPTION_ARG_CALLBACK , FUNC(clamp_top)              , "Limit upper reading barrier"                                 , "P"}    ,
         {"limit-mem"              , 'u' , HIDDEN           , G_OPTION_ARG_CALLBACK , FUNC(limit_mem)              , "Specify max. memory usage target"                            , "S"}    ,
-        {"paranoid-mem"           , 0   , HIDDEN           , G_OPTION_ARG_CALLBACK , FUNC(paranoid_mem)           , "Specify min. memory to use for in-progress paranoid hashing" , "S"}    ,
-        {"read-buffer"            , 0   , HIDDEN           , G_OPTION_ARG_CALLBACK , FUNC(read_buffer_mem)        , "Specify min. memory to use for read buffer during hashing"   , "S"}    ,
         {"sweep-size"             , 'u' , HIDDEN           , G_OPTION_ARG_CALLBACK , FUNC(sweep_size)             , "Specify max. bytes per pass when scanning disks"             , "S"}    ,
         {"sweep-files"            , 'u' , HIDDEN           , G_OPTION_ARG_CALLBACK , FUNC(sweep_count)            , "Specify max. file count per pass when scanning disks"        , "S"}    ,
         {"threads"                , 't' , HIDDEN           , G_OPTION_ARG_INT64    , &cfg->threads                , "Specify max. number of hasher threads"                       , "N"}    ,

--- a/lib/hash-utility.c
+++ b/lib/hash-utility.c
@@ -207,7 +207,6 @@ int rm_hasher_main(int argc, const char **argv) {
                                      FALSE,
                                      4096,
                                      1024 * 1024 * buffer_mbytes,
-                                     0,
                                      (RmHasherCallback)rm_hasher_callback,
                                      &tag);
 

--- a/lib/hasher.h
+++ b/lib/hasher.h
@@ -103,7 +103,6 @@ RmHasher *rm_hasher_new(RmDigestType digest_type,
                         gboolean use_buffered_read,
                         gsize buf_size,
                         guint64 cache_quota_bytes,
-                        guint64 target_kept_bytes,
                         RmHasherCallback joiner,
                         gpointer session_user_data);
 

--- a/lib/md-scheduler.c
+++ b/lib/md-scheduler.c
@@ -186,13 +186,7 @@ static void rm_mds_push_task_impl(RmMDSDevice *device, RmMDSTask *task) {
 static RmMDSTask *rm_mds_pop_task(RmMDSDevice *device) {
     RmMDSTask *task = NULL;
     g_mutex_lock(&device->lock);
-    {
-        if(device->sorted_tasks) {
-            task = device->sorted_tasks->data;
-            device->sorted_tasks =
-                g_slist_delete_link(device->sorted_tasks, device->sorted_tasks);
-        }
-    }
+    { task = rm_util_slist_pop(&device->sorted_tasks); }
     g_mutex_unlock(&device->lock);
     return task;
 }

--- a/lib/md-scheduler.c
+++ b/lib/md-scheduler.c
@@ -180,17 +180,6 @@ static void rm_mds_push_task_impl(RmMDSDevice *device, RmMDSTask *task) {
     g_mutex_unlock(&device->lock);
 }
 
-/** @brief Mutex-protected task popper
- **/
-
-static RmMDSTask *rm_mds_pop_task(RmMDSDevice *device) {
-    RmMDSTask *task = NULL;
-    g_mutex_lock(&device->lock);
-    { task = rm_util_slist_pop(&device->sorted_tasks); }
-    g_mutex_unlock(&device->lock);
-    return task;
-}
-
 /** @brief GCompareDataFunc wrapper for mds->prioritiser
  **/
 static gint rm_mds_compare(const RmMDSTask *a, const RmMDSTask *b,
@@ -234,7 +223,7 @@ static void rm_mds_factory(RmMDSDevice *device, RmMDS *mds) {
 
     /* process tasks from device->sorted_tasks */
     RmMDSTask *task = NULL;
-    while(processed < mds->pass_quota && (task = rm_mds_pop_task(device))) {
+    while(processed < mds->pass_quota && (task = rm_util_slist_pop(&device->sorted_tasks, &device->lock))) {
         if(mds->func(task->task_data, mds->user_data)) {
             /* task succeeded; update counters */
             ++processed;

--- a/lib/preprocess.c
+++ b/lib/preprocess.c
@@ -608,6 +608,7 @@ void rm_preprocess(RmSession *session) {
             /* free up the node table for the next group */
             g_hash_table_steal_all(node_table);
             if(tables->size_groups->data == NULL) {
+                /* zero size group after handling other lint; remove it */
                 tables->size_groups =
                     g_slist_delete_link(tables->size_groups, tables->size_groups);
             }

--- a/lib/preprocess.c
+++ b/lib/preprocess.c
@@ -618,7 +618,7 @@ void rm_preprocess(RmSession *session) {
             g_hash_table_steal_all(node_table);
             if(tables->size_groups->data == NULL) {
                 /* zero size group after handling other lint; remove it */
-                rm_util_slist_pop(&tables->size_groups);
+                tables->size_groups = g_slist_delete_link(tables->size_groups, tables->size_groups);
             }
             current_size_file = file;
         }

--- a/lib/preprocess.c
+++ b/lib/preprocess.c
@@ -566,7 +566,16 @@ static RmOff rm_pp_handler_other_lint(const RmSession *session) {
     return num_handled;
 }
 
-/* This does preprocessing including handling of "other lint" (non-dupes) */
+/* This does preprocessing including handling of "other lint" (non-dupes)
+ * After rm_preprocess(), all remaining duplicate candidates are in
+ * a jagged GSList of GSLists as follows:
+ * session->tables->size_groups->group1->file1a
+ *                                     ->file1b
+ *                                     ->file1c
+ *                             ->group2->file2a
+ *                                     ->file2b
+ *                                       etc
+ */
 void rm_preprocess(RmSession *session) {
     RmFileTables *tables = session->tables;
     GQueue *all_files = tables->all_files;

--- a/lib/preprocess.c
+++ b/lib/preprocess.c
@@ -488,7 +488,7 @@ static gboolean rm_pp_handle_inode_clusters(_U gpointer key, GQueue *inode_clust
 
         /* remove path doubles */
         session->total_filtered_files -=
-            rm_util_queue_foreach_remove(inode_cluster, (RmQRFunc)rm_pp_check_path_double,
+            rm_util_queue_foreach_remove(inode_cluster, (RmRFunc)rm_pp_check_path_double,
                                          session->tables->unique_paths_table);
         /* clear the hashtable ready for the next cluster */
         g_hash_table_remove_all(session->tables->unique_paths_table);
@@ -496,7 +496,7 @@ static gboolean rm_pp_handle_inode_clusters(_U gpointer key, GQueue *inode_clust
 
     /* process and remove other lint */
     session->total_filtered_files -= rm_util_queue_foreach_remove(
-        inode_cluster, (RmQRFunc)rm_pp_handle_other_lint, (RmSession *)session);
+        inode_cluster, (RmRFunc)rm_pp_handle_other_lint, (RmSession *)session);
 
     if(inode_cluster->length > 1) {
         /* bundle or free the non-head files */
@@ -513,7 +513,7 @@ static gboolean rm_pp_handle_inode_clusters(_U gpointer key, GQueue *inode_clust
          * the hardlinks depending on value of headfile->hardlinks.is_head.
          */
         session->total_filtered_files -= rm_util_queue_foreach_remove(
-            inode_cluster, (RmQRFunc)rm_pp_handle_hardlink, headfile);
+            inode_cluster, (RmRFunc)rm_pp_handle_hardlink, headfile);
     }
 
     /* update counters */

--- a/lib/preprocess.c
+++ b/lib/preprocess.c
@@ -609,8 +609,7 @@ void rm_preprocess(RmSession *session) {
             g_hash_table_steal_all(node_table);
             if(tables->size_groups->data == NULL) {
                 /* zero size group after handling other lint; remove it */
-                tables->size_groups =
-                    g_slist_delete_link(tables->size_groups, tables->size_groups);
+                rm_util_slist_pop(&tables->size_groups);
             }
             current_size_file = file;
         }

--- a/lib/replay.c
+++ b/lib/replay.c
@@ -344,45 +344,23 @@ static bool rm_parrot_check_types(RmCfg *cfg, RmFile *file) {
 //   GROUPWISE FIXES (SORT, FILTER, ...)   //
 /////////////////////////////////////////////
 
-static void rm_parrot_fix_match_opts(RmParrotCage *cage, GQueue *group) {
-    RmCfg *cfg = cage->session->cfg;
-    if(!(cfg->match_with_extension || cfg->match_without_extension ||
-         cfg->match_basename || cfg->unmatched_basenames)) {
-        return;
-    }
+/* RmHRFunc to remove file unless it has a twin in group */
+static int rm_parrot_fix_match_opts(RmFile *file, GQueue *group) {
+    int remove = 1;
 
-    /* That's probably a sucky way to do it, due to n^2,
-     * but I doubt that will make a large performance difference.
-     */
-
-    GList *iter = group->head;
-    while(iter) {
-        RmFile *file_a = iter->data;
-        bool delete = true;
-
-        for(GList *sub_iter = group->head; sub_iter; sub_iter = sub_iter->next) {
-            RmFile *file_b = sub_iter->data;
-            if(file_a == file_b) {
-                continue;
-            }
-
-            if(rm_file_cmp(file_a, file_b) == 0) {
-                delete = false;
-                break;
-            }
-        }
-
-        /* Remove this file */
-        if(delete) {
-            GList *tmp = iter;
-            iter = iter->next;
-            rm_file_destroy(file_a);
-            g_queue_delete_link(group, tmp);
-        } else {
-            iter = iter->next;
+    for(GList *iter = group->head; iter; iter = iter->next) {
+        if(file != iter->data && rm_file_cmp(file, iter->data) == 0) {
+            remove = 0;
+            break;
         }
     }
+
+    if(remove) {
+        rm_file_destroy(file);
+    }
+    return remove;
 }
+
 
 static void rm_parrot_fix_must_match_tagged(RmParrotCage *cage, GQueue *group) {
     RmCfg *cfg = cage->session->cfg;
@@ -441,7 +419,13 @@ static void rm_parrot_write_group(RmParrotCage *cage, GQueue *group) {
         }
     }
 
-    rm_parrot_fix_match_opts(cage, group);
+    if(cfg->match_with_extension || cfg->match_without_extension ||
+         cfg->match_basename || cfg->unmatched_basenames) {
+        /* This is probably a sucky way to do it, due to n^2,
+         * but I doubt that will make a large performance difference.
+         */
+        rm_util_queue_foreach_remove(group, (RmRFunc)rm_parrot_fix_match_opts, group);
+    }
     rm_parrot_fix_must_match_tagged(cage, group);
 
     g_queue_sort(group, (GCompareDataFunc)rm_shred_cmp_orig_criteria, cage->session);

--- a/lib/shredder.c
+++ b/lib/shredder.c
@@ -1139,12 +1139,12 @@ static void rm_shred_preprocess_input(RmShredTag *main) {
     rm_log_debug_line("preparing size groups for shredding (dupe finding)...");
     RmFileTables *tables = session->tables;
     while(tables->size_groups) {
-        GSList *files = rm_util_slist_pop(&tables->size_groups);
+        GSList *files = rm_util_slist_pop(&tables->size_groups, NULL);
 
         /* push files to shred group */
         RmShredGroup *group = NULL;
         while(files) {
-            RmFile *file = rm_util_slist_pop(&files);
+            RmFile *file = rm_util_slist_pop(&files, NULL);
             if(!group) {
                 /* create RmShredGroup using first file in size group as template*/
                 group = rm_shred_group_new(file);
@@ -1570,7 +1570,7 @@ void rm_shred_run(RmSession *session) {
     /* estimate mem used for RmFiles and allocate any leftovers to read buffer and/or
      * paranoid mem */
     RmOff mem_used = SHRED_AVERAGE_MEM_PER_FILE * session->shred_files_remaining;
-    RmOff read_buffer_mem = (gint64)cfg->total_mem - (gint64)mem_used;
+    RmOff read_buffer_mem = MAX ( 1024*1024, (gint64)cfg->total_mem - (gint64)mem_used );
 
     if(cfg->checksum_type == RM_DIGEST_PARANOID) {
         /* allocate any spare mem for paranoid hashing */

--- a/lib/shredder.c
+++ b/lib/shredder.c
@@ -1142,18 +1142,18 @@ static void rm_shred_preprocess_input(RmShredTag *main) {
     rm_log_debug_line("preparing size groups for shredding (dupe finding)...");
     RmFileTables *tables = session->tables;
     while(tables->size_groups) {
-        GSList *files = tables->size_groups->data;
-        RmShredGroup *group = NULL;
+        GSList *files = rm_util_slist_pop(&tables->size_groups);
+
         /* push files to shred group */
+        RmShredGroup *group = NULL;
         while(files) {
-            RmFile *file = files->data;
+            RmFile *file = rm_util_slist_pop(&files);
             if(!group) {
                 /* create RmShredGroup using first file in size group as template*/
                 group = rm_shred_group_new(file);
                 group->digest_type = session->cfg->checksum_type;
             }
             rm_shred_file_preprocess(group, file, main);
-            files = g_slist_delete_link(files, files);
         }
 
         if(group) {
@@ -1166,9 +1166,6 @@ static void rm_shred_preprocess_input(RmShredTag *main) {
             removed += rm_shred_group_preprocess(group);
         }
 
-        /* move to next size group */
-        tables->size_groups =
-            g_slist_delete_link(tables->size_groups, tables->size_groups);
     }
     rm_log_debug_line("...done at time %.3f; removed %u of %" LLU,
                       g_timer_elapsed(session->timer, NULL), removed,

--- a/lib/utilities.c
+++ b/lib/utilities.c
@@ -250,6 +250,16 @@ gint rm_util_slist_foreach_remove(GSList **list, RmRFunc func, gpointer user_dat
     return removed;
 }
 
+gpointer rm_util_slist_pop(GSList **list) {
+    gpointer result = NULL;
+    if (*list) {
+        result = (*list)->data;
+        *list = g_slist_delete_link(*list, *list);
+    }
+    return result;
+}
+
+
 /* checks uid and gid; returns 0 if both ok, else RM_LINT_TYPE_ corresponding *
  * to RmFile->filter types                                            */
 int rm_util_uid_gid_check(RmStat *statp, RmUserList *userlist) {

--- a/lib/utilities.c
+++ b/lib/utilities.c
@@ -250,11 +250,17 @@ gint rm_util_slist_foreach_remove(GSList **list, RmRFunc func, gpointer user_dat
     return removed;
 }
 
-gpointer rm_util_slist_pop(GSList **list) {
+gpointer rm_util_slist_pop(GSList **list, GMutex *lock) {
     gpointer result = NULL;
+    if (lock) {
+        g_mutex_lock(lock);
+    }
     if (*list) {
         result = (*list)->data;
         *list = g_slist_delete_link(*list, *list);
+    }
+    if (lock) {
+        g_mutex_unlock(lock);
     }
     return result;
 }

--- a/lib/utilities.h
+++ b/lib/utilities.h
@@ -286,7 +286,7 @@ gint rm_util_slist_foreach_remove(GSList **list, RmRFunc func, gpointer user_dat
 * Note this function returns null if the list is empty, or if the first item
 * has NULL as its data.
 */
-gpointer rm_util_slist_pop(GSList **list);
+gpointer rm_util_slist_pop(GSList **list, GMutex *lock);
 
 /**
  * @brief Return a pointer to the extension part of the file or NULL if none.

--- a/lib/utilities.h
+++ b/lib/utilities.h
@@ -279,6 +279,16 @@ gint rm_util_list_foreach_remove(GList **list, RmRFunc func, gpointer user_data)
 gint rm_util_slist_foreach_remove(GSList **list, RmRFunc func, gpointer user_data);
 
 /**
+* @brief Pop the first element from a GSList
+*
+* @return pointer to the data associated with the popped element.
+*
+* Note this function returns null if the list is empty, or if the first item
+* has NULL as its data.
+*/
+gpointer rm_util_slist_pop(GSList **list);
+
+/**
  * @brief Return a pointer to the extension part of the file or NULL if none.
  *
  * @return: a pointer >= basename or NULL.

--- a/lib/utilities.h
+++ b/lib/utilities.h
@@ -230,14 +230,14 @@ GQueue *rm_hash_table_setdefault(GHashTable *table, gpointer key, RmNewFunc defa
 void rm_util_queue_push_tail_queue(GQueue *dest, GQueue *src);
 
 /**
- * @brief Function prototype for remove-iterating over a GQueue.
+ * @brief Function prototype for remove-iterating over a GQueue/GList/GSList.
  *
  * @param data current element
  * @param user_data optional user_data
  *
  * @return True if the element should be removed.
  */
-typedef gboolean (*RmQRFunc)(gpointer data, gpointer user_data);
+typedef gboolean (*RmRFunc)(gpointer data, gpointer user_data);
 
 /**
  * @brief Iterate over a GQueue and call `func` on each element.
@@ -250,7 +250,33 @@ typedef gboolean (*RmQRFunc)(gpointer data, gpointer user_data);
  *
  * @return Number of removed items.
  */
-gint rm_util_queue_foreach_remove(GQueue *queue, RmQRFunc func, gpointer user_data);
+gint rm_util_queue_foreach_remove(GQueue *queue, RmRFunc func, gpointer user_data);
+
+/**
+ * @brief Iterate over a GList and call `func` on each element.
+ *
+ * If func returns true, the element is removed from the GList.
+ *
+ * @param list pointer to GList to iterate
+ * @param func Function that evaluates the removal of the item
+ * @param user_data optional user data
+ *
+ * @return Number of removed items.
+ */
+gint rm_util_list_foreach_remove(GList **list, RmRFunc func, gpointer user_data);
+
+/**
+ * @brief Iterate over a GSList and call `func` on each element.
+ *
+ * If func returns true, the element is removed from the GSList.
+ *
+ * @param list pointer to GSList to iterate
+ * @param func Function that evaluates the removal of the item
+ * @param user_data optional user data
+ *
+ * @return Number of removed items.
+ */
+gint rm_util_slist_foreach_remove(GSList **list, RmRFunc func, gpointer user_data);
 
 /**
  * @brief Return a pointer to the extension part of the file or NULL if none.


### PR DESCRIPTION
A range of tidy-ups and rationalisations.  Only user impact should be removal of --max-paranoid-mem option (https://github.com/sahib/rmlint/commit/73d4ce3940979aed997d006ba0c7bfa6d85bfe06); --limit-mem is now sufficient.