### PR TITLE
Fix compile error when RM_MOUNTTABLE_IS_USABLE not defined

### DIFF
--- a/lib/utilities.c
+++ b/lib/utilities.c
@@ -903,7 +903,7 @@ dev_t rm_mounts_get_disk_id(RmMountTable *self, dev_t dev, const char *path) {
         }
     }
 #else
-    (void)partition;
+    (void)dev;
     (void)path;
     return 0;
 #endif


### PR DESCRIPTION
I got compile error on FreeBSD clang version 3.4.1/FreeBSD 10.1.
```
Compiling ==> lib/utilities.c
lib/utilities.c:906:11: error: use of undeclared identifier 'partition'
    (void)partition;
          ^
lib/utilities.c:856:55: warning: unused parameter 'dev' [-Wunused-parameter]
dev_t rm_mounts_get_disk_id(RmMountTable *self, dev_t dev, const char *path) {
                                                      ^
1 warning and 1 error generated.
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sahib/rmlint/164)
<!-- Reviewable:end -->
