### PR TITLE
The gui breaks when a blank optical disc is in the drive as it doesn't have a path

### DIFF
--- a/gui/shredder/views/locations.py
+++ b/gui/shredder/views/locations.py
@@ -318,6 +318,9 @@ class LocationView(View):
 
         # Mounted volumes:
         for mount in self.volume_monitor.get_mounts():
+            if mount.get_root().get_path() is None:
+                continue
+
             info = mount.get_root().query_filesystem_info(
                 ','.join([
                     Gio.FILE_ATTRIBUTE_FILESYSTEM_SIZE,


### PR DESCRIPTION
File "/usr/lib/python3.5/site-packages/shredder/views/locations.py", line 360, in add_entry
    path = path.strip()
AttributeError: 'NoneType' object has no attribute 'strip'

This patch fixes the bug by skipping volumes without path.