### PR TITLE
Default prefix to /usr

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -429,7 +429,7 @@ link_shared_library_message = '%sLinking Shared Library %s==> %s$TARGET%s' % \
 ###########################################################################
 
 AddOption(
-    '--prefix', default='/usr/local',
+    '--prefix', default='/usr',
     dest='prefix', type='string', nargs=1,
     action='store', metavar='DIR', help='installation prefix'
 )


### PR DESCRIPTION
 to simply work "out of the box".
It is not complicated, to change the prefix, but it should work by default.