### PR TITLE
Add keywords to desktop file.

### DIFF
--- a/gui/shredder.desktop
+++ b/gui/shredder.desktop
@@ -7,3 +7,4 @@ TryExec=rmlint
 Exec=rmlint --gui
 Icon=shredder
 Categories=System;
+Keywords=remove;duplicate;files;filesystem;lint;


### PR DESCRIPTION
Lintian requires that desktop files shipped with Debian packages have a Keywords entry. This is what I have added for now. Feel free to change it to ones you think are more appropriate.

Cheers.