### PR TITLE
Fix FTBFS for hurd-i386.

### DIFF
--- a/lib/fts/fts.c
+++ b/lib/fts/fts.c
@@ -101,6 +101,10 @@ static int fts_safe_changedir(const FTS *, const FTSENT *, int, const char *);
 #undef FTS_WHITEOUT
 #endif
 
+#ifndef MAXPATHLEN
+#define MAXPATHLEN 4096
+#endif
+
 FTS *fts_open(char *const *argv, int options,
               int (*compar)(const FTSENT **, const FTSENT **)) {
     FTS *sp;


### PR DESCRIPTION
Hurd does not have path length restrictions, so doesn't define
MAXPATHLEN in <sys/param.h>. Defining it as 4096 when not defined
is a sufficient workaround, since the code is able to adapt when
paths are actually longer than this value.