### PR TITLE
Prevent app window from getting stuck in fullscreen mode.

### DIFF
--- a/gui/shredder/window.py
+++ b/gui/shredder/window.py
@@ -18,6 +18,7 @@ from gettext import gettext
 # External:
 from gi.repository import Gtk
 from gi.repository import Gio
+from gi.repository import Gdk
 
 # Internal:
 import shredder
@@ -260,6 +261,7 @@ class MainWindow(Gtk.ApplicationWindow):
         self.headerbar.pack_end(menu_button)
         self.headerbar.pack_end(search_button)
         self.add(self.main_grid)
+        self.connect('window-state-event', self._on_window_state_event)
 
     def add_header_widget(self, widget, align=Gtk.Align.END):
         """Add a widget to the header, either left or right of the title.
@@ -277,3 +279,11 @@ class MainWindow(Gtk.ApplicationWindow):
         """Remove a previously added headerwidget. Noop if it did not exist"""
         if widget in self.headerbar:
             self.headerbar.remove(widget)
+
+    def _on_window_state_event(self, widget, ev):
+        """Maximize app window instead of going fullscreen,
+        so we never lose the header widget.
+        """
+        if ev.new_window_state & Gdk.WindowState.FULLSCREEN:
+            self.unfullscreen()
+            self.maximize()


### PR DESCRIPTION
I'm not sure if this is the best solution to this problem, but in Xfce you can end up stuck in fullscreen mode with no way out but to close (using keyboard shortcuts) and restart the application. This is because the title bar is not displayed in fullscreen mode, and without it you have no access to the window menu which pops up when you right click on the title bar.

I couldn't find any window hints that might help with this problem, so the way I went about it was to toggle fullscreen mode and maximise the window instead whenever the user tries to switch to fullscreen mode. However, if fullscreen mode really does need to be made available, I thought perhaps there could be a shortcut key like F11 to toggle it back.

Thanks.