### PR TITLE
Use #if not #ifdef with HAVE_SYSMACROS_H

### DIFF
--- a/lib/utilities.c
+++ b/lib/utilities.c
@@ -35,7 +35,7 @@
 /* Be safe: This header is not essential and might be missing on some systems.
  * We only include it here, because it fixes some recent warning...
  * */
-#ifdef HAVE_SYSMACROS_H
+#if HAVE_SYSMACROS_H
 # include <sys/sysmacros.h>
 #endif
 


### PR DESCRIPTION
If scons sets HAVE_SYSMACROS_H to 0, that still counts as being defined.
So use #if instead of #ifdef.

Prevents build failure on macOS.