### PR TITLE
fix centos7 spec URL & split shredder to new package

### DIFF
--- a/pkg/centos/rmlint.spec
+++ b/pkg/centos/rmlint.spec
@@ -5,13 +5,21 @@ Summary:        rmlint finds space waste and other broken things on your filesys
 Group:          Applications/System
 License:        GPLv3
 URL:            http://rmlint.rtfd.org
-Source0:        https://github.com/sahib/rmlint/archive/rmlint-%{version}.tar.gz
+Source0:        https://github.com/sahib/rmlint/archive/v%{version}/rmlint-%{version}.tar.gz
 Requires:       glib2 libblkid elfutils-libelf json-glib
 BuildRequires:  scons gettext libblkid-devel elfutils-libelf-devel glib2-devel json-glib-devel
 
 %description
 rmlint finds space waste and other broken things and offers to remove it. It is
 especially an extremely fast tool to remove duplicates from your filesystem.
+
+%package shredder
+Summary:  GUI for rmlint
+Group:    Applications/System
+Requires: rmlint
+
+%description shredder
+shredder is a GUI frontend to the rmlint utility.
 
 %prep
 %setup -q
@@ -39,7 +47,16 @@ rm -rf %{buildroot}
 # %{_libdir}/*
 # %{_includedir}/*
 
+%files shredder
+%{python3_sitelib}/*
+%{_datadir}/applications/shredder.desktop
+%{_datadir}/glib-2.0/schemas/*
+%{_datadir}/icons/hicolor/scalable/apps/shredder.svg
+
 %changelog
+* Sat Dec 16 2017 Patrick Hemmer <patrick.hemmer@gmail.com> - 2.6.1
+- Fix source URL.
+- Split shredder into subpackage.
 * Fri Oct 27 2017 Vince Mele <vincentmele@gmail.com> - 2.6.1
 - Update to version 2.6.1. Remove python-sphinx3 dependency.
 - Use setup -q.


### PR DESCRIPTION
This fixes 2 issues:

The download URL was incorrect:
```
warning: Downloading https://github.com/sahib/rmlint/archive/rmlint-2.6.1.tar.gz to /home/phemmer/rpmbuild/SOURCES/rmlint-2.6.1.tar.gz
curl: (22) The requested URL returned error: 404 Not Found
error: Couldn't download https://github.com/sahib/rmlint/archive/rmlint-2.6.1.tar.gz
```

The shredder files weren't specified in the `%files` section:
```
error: Installed (but unpackaged) file(s) found:
   /usr/lib/python3.4/site-packages/Shredder-2.6.1.Penetrating.Pineapple-py3.4.egg-info
   /usr/lib/python3.4/site-packages/shredder/__init__.py
   /usr/lib/python3.4/site-packages/shredder/__main__.py
   /usr/lib/python3.4/site-packages/shredder/__pycache__/__init__.cpython-34.pyc
   /usr/lib/python3.4/site-packages/shredder/__pycache__/__init__.cpython-34.pyo
   /usr/lib/python3.4/site-packages/shredder/__pycache__/__main__.cpython-34.pyc
   /usr/lib/python3.4/site-packages/shredder/__pycache__/__main__.cpython-34.pyo
   /usr/lib/python3.4/site-packages/shredder/__pycache__/about.cpython-34.pyc
   /usr/lib/python3.4/site-packages/shredder/__pycache__/about.cpython-34.pyo
   /usr/lib/python3.4/site-packages/shredder/__pycache__/application.cpython-34.pyc
   /usr/lib/python3.4/site-packages/shredder/__pycache__/application.cpython-34.pyo
   /usr/lib/python3.4/site-packages/shredder/__pycache__/chart.cpython-34.pyc
   /usr/lib/python3.4/site-packages/shredder/__pycache__/chart.cpython-34.pyo
   /usr/lib/python3.4/site-packages/shredder/__pycache__/cmdline.cpython-34.pyc
   /usr/lib/python3.4/site-packages/shredder/__pycache__/cmdline.cpython-34.pyo
   /usr/lib/python3.4/site-packages/shredder/__pycache__/logger.cpython-34.pyc
   /usr/lib/python3.4/site-packages/shredder/__pycache__/logger.cpython-34.pyo
   /usr/lib/python3.4/site-packages/shredder/__pycache__/query.cpython-34.pyc
   /usr/lib/python3.4/site-packages/shredder/__pycache__/query.cpython-34.pyo
   /usr/lib/python3.4/site-packages/shredder/__pycache__/runner.cpython-34.pyc
   /usr/lib/python3.4/site-packages/shredder/__pycache__/runner.cpython-34.pyo
   /usr/lib/python3.4/site-packages/shredder/__pycache__/tree.cpython-34.pyc
   /usr/lib/python3.4/site-packages/shredder/__pycache__/tree.cpython-34.pyo
   /usr/lib/python3.4/site-packages/shredder/__pycache__/util.cpython-34.pyc
   /usr/lib/python3.4/site-packages/shredder/__pycache__/util.cpython-34.pyo
   /usr/lib/python3.4/site-packages/shredder/__pycache__/window.cpython-34.pyc
   /usr/lib/python3.4/site-packages/shredder/__pycache__/window.cpython-34.pyo
   /usr/lib/python3.4/site-packages/shredder/about.py
   /usr/lib/python3.4/site-packages/shredder/application.py
   /usr/lib/python3.4/site-packages/shredder/chart.py
   /usr/lib/python3.4/site-packages/shredder/cmdline.py
   /usr/lib/python3.4/site-packages/shredder/logger.py
   /usr/lib/python3.4/site-packages/shredder/query.py
   /usr/lib/python3.4/site-packages/shredder/resources/shredder.gresource
   /usr/lib/python3.4/site-packages/shredder/runner.py
   /usr/lib/python3.4/site-packages/shredder/tree.py
   /usr/lib/python3.4/site-packages/shredder/util.py
   /usr/lib/python3.4/site-packages/shredder/views/__init__.py
   /usr/lib/python3.4/site-packages/shredder/views/__pycache__/__init__.cpython-34.pyc
   /usr/lib/python3.4/site-packages/shredder/views/__pycache__/__init__.cpython-34.pyo
   /usr/lib/python3.4/site-packages/shredder/views/__pycache__/editor.cpython-34.pyc
   /usr/lib/python3.4/site-packages/shredder/views/__pycache__/editor.cpython-34.pyo
   /usr/lib/python3.4/site-packages/shredder/views/__pycache__/locations.cpython-34.pyc
   /usr/lib/python3.4/site-packages/shredder/views/__pycache__/locations.cpython-34.pyo
   /usr/lib/python3.4/site-packages/shredder/views/__pycache__/runner.cpython-34.pyc
   /usr/lib/python3.4/site-packages/shredder/views/__pycache__/runner.cpython-34.pyo
   /usr/lib/python3.4/site-packages/shredder/views/__pycache__/settings.cpython-34.pyc
   /usr/lib/python3.4/site-packages/shredder/views/__pycache__/settings.cpython-34.pyo
   /usr/lib/python3.4/site-packages/shredder/views/editor.py
   /usr/lib/python3.4/site-packages/shredder/views/locations.py
   /usr/lib/python3.4/site-packages/shredder/views/runner.py
   /usr/lib/python3.4/site-packages/shredder/views/settings.py
   /usr/lib/python3.4/site-packages/shredder/window.py
   /usr/share/applications/shredder.desktop
   /usr/share/glib-2.0/schemas/gschemas.compiled
   /usr/share/glib-2.0/schemas/org.gnome.Shredder.gschema.xml
   /usr/share/icons/hicolor/scalable/apps/shredder.svg
```

Instead of adding the shredder files to the main `rmlint` package, I created a new subpackage for shredder. I opted for this as I imagine many users (myself included) don't have a GUI on their CentOS systems, and thus have no use for a GUI utility.

CC: @vincentmele 