### PR TITLE
Fix percentage in progress bar on rmlint.sh

### DIFF
--- a/lib/formats/sh.sh
+++ b/lib/formats/sh.sh
@@ -51,7 +51,7 @@ print_progress_prefix() {
         if [ $((PROGRESS_TOTAL)) -gt 0 ]; then
             PROGRESS_PERC=$((PROGRESS_CURR * 100 / PROGRESS_TOTAL))
         fi
-        printf "${COL_BLUE}[% 3d%%]${COL_RESET} $PROGRESS_PERC"
+        printf "${COL_BLUE}[% 3d%%]${COL_RESET} " $PROGRESS_PERC
         if [ $# -eq "1" ]; then
             PROGRESS_CURR=$((PROGRESS_CURR+$1))
         else


### PR DESCRIPTION
... which is broken due to incorrect quoting. My fix does correct the quoting issue introduced in aa9b063827da6903770a1d36debae71fb669d8a6. 

Also remove trailing spaces.

Please don't hesitate to ask any question or give me feedback on this.