### PR TITLE
Hardlinks

### DIFF
--- a/lib/formats/sh.sh
+++ b/lib/formats/sh.sh
@@ -179,12 +179,11 @@ cp_symlink() {
     echo "${COL_YELLOW}Symlinking to original: ${COL_RESET}$1"
     if original_check "$1" "$2"; then
         if [ -z "$DO_DRY_RUN" ]; then
-            touch -mr "$1" "$0"
-            if [ -d "$1" ]; then
-                rm -rf "$1"
-            fi
-            cp --remove-destination --archive --symbolic-link "$2" "$1"
-            touch -mr "$0" "$1"
+            # replace duplicate with symlink
+            rm "$1"
+            ln -s "$2" "$1"
+            # make the symlink's mtime the same as the original
+            touch -mr "$2" -h "$1"
         fi
     fi
 }

--- a/lib/formats/sh.sh
+++ b/lib/formats/sh.sh
@@ -174,6 +174,11 @@ cp_symlink() {
 }
 
 cp_hardlink() {
+    if [ -d "$1" ]; then
+        # for duplicate dir's, can't hardlink so use symlink
+        cp_symlink "$@"
+        return $?
+    fi
     print_progress_prefix
     echo "${COL_YELLOW}Hardlinking to original: ${COL_RESET}$1"
     if original_check "$1" "$2"; then
@@ -191,6 +196,11 @@ cp_hardlink() {
 }
 
 cp_reflink() {
+    if [ -d "$1" ]; then
+        # for duplicate dir's, can't clone so use symlink
+        cp_symlink "$@"
+        return $?
+    fi
     print_progress_prefix
     # reflink $1 to $2's data, preserving $1's  mtime
     echo "${COL_YELLOW}Reflinking to original: ${COL_RESET}$1"

--- a/lib/formats/sh.sh
+++ b/lib/formats/sh.sh
@@ -180,7 +180,7 @@ cp_symlink() {
     if original_check "$1" "$2"; then
         if [ -z "$DO_DRY_RUN" ]; then
             # replace duplicate with symlink
-            rm "$1"
+            rm -rf "$1"
             ln -s "$2" "$1"
             # make the symlink's mtime the same as the original
             touch -mr "$2" -h "$1"

--- a/lib/formats/sh.sh
+++ b/lib/formats/sh.sh
@@ -159,21 +159,6 @@ original_check() {
     fi
 }
 
-cp_hardlink() {
-    print_progress_prefix
-    echo "${COL_YELLOW}Hardlinking to original: ${COL_RESET}$1"
-    if original_check "$1" "$2"; then
-        if [ -z "$DO_DRY_RUN" ]; then
-            # If it's a directory cp will create a new copy into
-            # the destination path. This would lead to more wasted space...
-            if [ -d "$1" ]; then
-                rm -rf "$1"
-            fi
-            cp --remove-destination --archive --link "$2" "$1"
-        fi
-    fi
-}
-
 cp_symlink() {
     print_progress_prefix
     echo "${COL_YELLOW}Symlinking to original: ${COL_RESET}$1"
@@ -184,6 +169,23 @@ cp_symlink() {
             ln -s "$2" "$1"
             # make the symlink's mtime the same as the original
             touch -mr "$2" -h "$1"
+        fi
+    fi
+}
+
+cp_hardlink() {
+    print_progress_prefix
+    echo "${COL_YELLOW}Hardlinking to original: ${COL_RESET}$1"
+    if original_check "$1" "$2"; then
+        if [ -z "$DO_DRY_RUN" ]; then
+            # If it's a directory cp will create a new copy into
+            # the destination path. This would lead to more wasted space...
+            if [ -d "$1" ]; then
+                rm -rf "$1"
+            fi
+            # replace duplicate with hardlink
+            rm "$1"
+            ln "$2" "$1"
         fi
     fi
 }


### PR DESCRIPTION
Should fix #275.
Also changes handling of duplicate dirs for `cp_hardlink()` and `cp_reflink()` from deletion to symlink.  Arguably neither deletion nor symlink is ideal; we could instead consider banning combinations of options `-D` with `-c sh:hardlink` but I think the symlink option is a reasonable compromise.