### PR TITLE
Fix broken ./rmlint.sh percentage-progress formatting

### DIFF
--- a/lib/formats/sh.c.in
+++ b/lib/formats/sh.c.in
@@ -326,6 +326,7 @@ static void rm_fmt_head(RmSession *session, RmFmtHandler *parent, FILE *out) {
     char *equal_extra_args = rm_fmt_sh_get_extra_equal_args(session);
 
     /* Fill in all placeholders in the script template */
+    /* This is a brittle hack of which the author should be ashamed. */
     fprintf(
         out, SH_SCRIPT_TEMPLATE_HEAD,
         session->cfg->iwd,
@@ -333,6 +334,7 @@ static void rm_fmt_head(RmSession *session, RmFmtHandler *parent, FILE *out) {
         (session->cfg->full_argv0_path) ? (session->cfg->full_argv0_path) : "$(which rmlint)",
         rm_util_get_username(),
         rm_util_get_groupname(),
+        "'%s[%3d%%]%s '", /* The progress format */
         equal_extra_args,
         (self->user_cmd) ? self->user_cmd : "echo 'no user command defined.'",
         (session->cfg->joined_argv) ? (session->cfg->joined_argv) : "unknown_commandline"

--- a/lib/formats/sh.sh
+++ b/lib/formats/sh.sh
@@ -51,7 +51,7 @@ print_progress_prefix() {
         if [ $((PROGRESS_TOTAL)) -gt 0 ]; then
             PROGRESS_PERC=$((PROGRESS_CURR * 100 / PROGRESS_TOTAL))
         fi
-        printf "${COL_BLUE}[% 3d%%]${COL_RESET} $PROGRESS_PERC"
+        printf %s "${COL_BLUE}" "$PROGRESS_PERC" "${COL_RESET}"
         if [ $# -eq "1" ]; then
             PROGRESS_CURR=$((PROGRESS_CURR+$1))
         else


### PR DESCRIPTION
It used to look like this:

    [  0%] 0Keeping:  /tmp/o/at/blah/g
    [  0%] 16Cloning to: /tmp/o/at/blah/h
    [  0%] 33Keeping:  /tmp/o/at/blah/a
    [  0%] 50Cloning to: /tmp/o/at/blah/c
    [  0%] 66Cloning to: /tmp/o/at/blah/d
    [  0%] 83Cloning to: /tmp/o/at/blah/e
    [  0%] 100Done!

Now it looks like this:

    [  0%] Keeping:  /tmp/o/at/blah/g
    [ 16%] Cloning to: /tmp/o/at/blah/h
    [ 33%] Keeping:  /tmp/o/at/blah/a
    [ 50%] Cloning to: /tmp/o/at/blah/c
    [ 66%] Cloning to: /tmp/o/at/blah/d
    [ 83%] Cloning to: /tmp/o/at/blah/e
    [100%] Done!