### PR TITLE
A quick clean up

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -706,9 +706,10 @@ if conf.env['HAVE_LIBELF']:
 cc_O_option = '-O'
 if ARGUMENTS.get('DEBUG') == "1":
     print("Compiling with gdb extra debug symbols")
-    conf.env.Append(CCFLAGS=['-ggdb3', '-fno-inline'])
+    conf.env.Append(CCFLAGS=['-DRM_DEBUG', '-ggdb3', '-fno-inline'])
     cc_O_option += (ARGUMENTS.get('O') or '0')
 else:
+    conf.env.Append(CCFLAGS=['-DG_DISABLE_ASSERT'])
     conf.env.Append(LINKFLAGS=['-s'])
     cc_O_option += (ARGUMENTS.get('O') or DEFAULT_OPTIMISATION)
 

--- a/lib/checksum.c
+++ b/lib/checksum.c
@@ -850,7 +850,7 @@ RmDigest *rm_digest_new(RmDigestType type, RmOff seed) {
 }
 
 void rm_digest_release_buffers(RmDigest *digest) {
-    rm_assert_gentle(digest->type == RM_DIGEST_PARANOID);
+    g_assert(digest->type == RM_DIGEST_PARANOID);
     rm_digest_paranoid_release_buffers(digest->state);
 }
 
@@ -869,7 +869,7 @@ void rm_digest_update(RmDigest *digest, const unsigned char *data, RmOff size) {
 }
 
 void rm_digest_buffered_update(RmBuffer *buffer) {
-    rm_assert_gentle(buffer);
+    g_assert(buffer);
     RmDigest *digest = buffer->digest;
     if(digest->type != RM_DIGEST_PARANOID) {
         rm_digest_update(digest, buffer->data, buffer->len);
@@ -881,7 +881,7 @@ void rm_digest_buffered_update(RmBuffer *buffer) {
 }
 
 RmDigest *rm_digest_copy(RmDigest *digest) {
-    rm_assert_gentle(digest);
+    g_assert(digest);
 
     RmDigest *copy = g_slice_copy(sizeof(RmDigest), digest);
 
@@ -908,7 +908,7 @@ guint rm_digest_hash(RmDigest *digest) {
     bytes = digest->bytes;
 
     if(buf != NULL) {
-        rm_assert_gentle(bytes >= sizeof(guint));
+        g_assert(bytes >= sizeof(guint));
         hash = *(guint *)buf;
         g_slice_free1(bytes, buf);
     }
@@ -916,7 +916,7 @@ guint rm_digest_hash(RmDigest *digest) {
 }
 
 gboolean rm_digest_equal(RmDigest *a, RmDigest *b) {
-    rm_assert_gentle(a && b);
+    g_assert(a && b);
 
     if(a->type != b->type) {
         return false;

--- a/lib/checksum.c
+++ b/lib/checksum.c
@@ -753,7 +753,6 @@ static const RmDigestInterface paranoid_interface = {
 
 static const RmDigestInterface *rm_digest_get_interface(RmDigestType type) {
     static const RmDigestInterface *digest_interfaces[] = {
-        [RM_DIGEST_UNKNOWN] = NULL,
         [RM_DIGEST_MURMUR] = &murmur_interface,
         [RM_DIGEST_METRO] = &metro_interface,
         [RM_DIGEST_METRO256] = &metro256_interface,
@@ -783,19 +782,16 @@ static const RmDigestInterface *rm_digest_get_interface(RmDigestType type) {
         [RM_DIGEST_HIGHWAY256] = &highway256_interface,
     };
 
-    if(type != RM_DIGEST_UNKNOWN && type < RM_DIGEST_SENTINEL &&
-       digest_interfaces[type]) {
-        return digest_interfaces[type];
-    }
-    rm_log_error_line("No digest interface for enum %i", type);
-    g_assert_not_reached();
+    g_assert(type < RM_DIGEST_SENTINEL);
+    g_assert(type != RM_DIGEST_UNKNOWN);
+    g_assert(digest_interfaces[type]);
+
+    return digest_interfaces[type];
 }
 
 static void rm_digest_table_insert(GHashTable *code_table, char *name,
                                    RmDigestType type) {
-    if(g_hash_table_contains(code_table, name)) {
-        rm_log_error_line("Duplicate entry for %s in rm_init_digest_type_table()", name);
-    }
+    g_assert(!g_hash_table_contains(code_table, name));
     g_hash_table_insert(code_table, name, GUINT_TO_POINTER(type));
 }
 

--- a/lib/cmdline.c
+++ b/lib/cmdline.c
@@ -1500,6 +1500,8 @@ bool rm_cmd_parse_args(int argc, char **argv, RmSession *session) {
         cfg->with_stdout_color = cfg->with_stderr_color = 0;
     }
 
+    g_assert(!(cfg->follow_symlinks && cfg->see_symlinks));
+
     if(cfg->keep_all_tagged && cfg->keep_all_untagged) {
         error = g_error_new(
             RM_ERROR_QUARK, 0,
@@ -1509,9 +1511,6 @@ bool rm_cmd_parse_args(int argc, char **argv, RmSession *session) {
                             _("-q (--clamp-low) should be lower than -Q (--clamp-top)"));
     } else if(!rm_cmd_set_outputs(session, &error)) {
         /* Something wrong with the outputs */
-    } else if(cfg->follow_symlinks && cfg->see_symlinks) {
-        rm_log_error("Program error: Cannot do both follow_symlinks and see_symlinks");
-        rm_assert_gentle_not_reached();
     } else if(cfg->keep_all_tagged && cfg->must_match_untagged) {
         error = \
             g_error_new(

--- a/lib/cmdline.c
+++ b/lib/cmdline.c
@@ -386,8 +386,8 @@ static bool rm_cmd_read_paths_from_stdin(RmSession *session, bool is_prefd,
 
 static bool rm_cmd_parse_output_pair(RmSession *session, const char *pair,
                                      GError **error) {
-    rm_assert_gentle(session);
-    rm_assert_gentle(pair);
+    g_assert(session);
+    g_assert(pair);
 
     char *separator = strchr(pair, ':');
     char *full_path = NULL;
@@ -1608,7 +1608,7 @@ int rm_cmd_main(RmSession *session) {
                       g_timer_elapsed(session->timer, NULL), session->total_files);
 
     if(cfg->merge_directories) {
-        rm_assert_gentle(cfg->cache_file_structs);
+        g_assert(cfg->cache_file_structs);
 
         /* Currently we cannot use -D and the cloning on btrfs, since this assumes the same layout
          * on two dupicate directories which is likely not a valid assumption.

--- a/lib/config.h.in
+++ b/lib/config.h.in
@@ -169,18 +169,4 @@ typedef guint64 RmOff;
 /* Domain for reporting errors. Needed by GOptions */
 #define RM_ERROR_QUARK (g_quark_from_static_string("rmlint"))
 
-#ifndef RM_DEBUG
-    #define rm_assert_gentle(cond)
-#else
-    #define rm_assert_gentle(cond)                                                                \
-        if(!(cond)) {{                                                                            \
-            rm_log_error_line("BUG: Assertion failed at `%s@%d`: %s", __FILE__, __LINE__, #cond); \
-            rm_log_error_line("     Will try to continue in 2 seconds. Expect crashes.");         \
-            g_usleep(2 * 1000 * 1000);                                                            \
-        }}
-#endif
-
-#define RM_NOT_REACHED (0)
-#define rm_assert_gentle_not_reached() rm_assert_gentle(RM_NOT_REACHED)
-
 #endif

--- a/lib/config.h.in
+++ b/lib/config.h.in
@@ -169,13 +169,16 @@ typedef guint64 RmOff;
 /* Domain for reporting errors. Needed by GOptions */
 #define RM_ERROR_QUARK (g_quark_from_static_string("rmlint"))
 
-#define rm_assert_gentle(cond)                                                                \
-    if(!(cond)) {{                                                                            \
-        rm_log_error_line("BUG: Assertion failed at `%s@%d`: %s", __FILE__, __LINE__, #cond); \
-        rm_log_error_line("     Will try to continue in 2 seconds. Expect crashes.");         \
-        g_usleep(2 * 1000 * 1000);                                                            \
-    }}
-
+#ifndef RM_DEBUG
+    #define rm_assert_gentle(cond)
+#else
+    #define rm_assert_gentle(cond)                                                                \
+        if(!(cond)) {{                                                                            \
+            rm_log_error_line("BUG: Assertion failed at `%s@%d`: %s", __FILE__, __LINE__, #cond); \
+            rm_log_error_line("     Will try to continue in 2 seconds. Expect crashes.");         \
+            g_usleep(2 * 1000 * 1000);                                                            \
+        }}
+#endif
 
 #define RM_NOT_REACHED (0)
 #define rm_assert_gentle_not_reached() rm_assert_gentle(RM_NOT_REACHED)

--- a/lib/file.c
+++ b/lib/file.c
@@ -103,7 +103,7 @@ void rm_file_set_path(RmFile *file, char *path) {
 }
 
 void rm_file_build_path(RmFile *file, char *buf) {
-    rm_assert_gentle(file);
+    g_assert(file);
 
     rm_trie_build_path(&file->session->cfg->file_trie, file->folder, buf, PATH_MAX);
 }
@@ -182,7 +182,7 @@ static gint rm_file_foreach_hardlink(RmFile *f, RmRFunc func, gpointer user_data
 void rm_file_cluster_add(RmFile *host, RmFile *guest) {
     g_assert(host);
     g_assert(guest);
-    rm_assert_gentle(!guest->cluster || host == guest);
+    g_assert(!guest->cluster || host == guest);
     if(!host->cluster) {
         host->cluster = g_queue_new();
         if(guest != host) {
@@ -195,7 +195,7 @@ void rm_file_cluster_add(RmFile *host, RmFile *guest) {
 
 void rm_file_cluster_remove(RmFile *file) {
     g_assert(file);
-    rm_assert_gentle(file->cluster);
+    g_assert(file->cluster);
 
     g_queue_remove(file->cluster, file);
     if(file->cluster->length == 0) {
@@ -234,7 +234,7 @@ static gint rm_file_count(RmFile *file, gint type) {
     case RM_FILE_COUNT_NEW:
         return file->is_new;
     default:
-        rm_assert_gentle_not_reached();
+        g_assert_not_reached();
         return 0;
     }
 }

--- a/lib/file.c
+++ b/lib/file.c
@@ -180,6 +180,8 @@ static gint rm_file_foreach_hardlink(RmFile *f, RmRFunc func, gpointer user_data
 }
 
 void rm_file_cluster_add(RmFile *host, RmFile *guest) {
+    g_assert(host);
+    g_assert(guest);
     rm_assert_gentle(!guest->cluster || host == guest);
     if(!host->cluster) {
         host->cluster = g_queue_new();
@@ -192,6 +194,7 @@ void rm_file_cluster_add(RmFile *host, RmFile *guest) {
 }
 
 void rm_file_cluster_remove(RmFile *file) {
+    g_assert(file);
     rm_assert_gentle(file->cluster);
 
     g_queue_remove(file->cluster, file);
@@ -231,7 +234,7 @@ static gint rm_file_count(RmFile *file, gint type) {
     case RM_FILE_COUNT_NEW:
         return file->is_new;
     default:
-        rm_assert_gentle(FALSE);
+        rm_assert_gentle_not_reached();
         return 0;
     }
 }

--- a/lib/formats.c
+++ b/lib/formats.c
@@ -81,7 +81,7 @@ static void rm_fmt_group_destroy(RmFmtTable *self, RmFmtGroup *group) {
 }
 
 static void rm_fmt_handler_free(RmFmtHandler *handler) {
-    rm_assert_gentle(handler);
+    g_assert(handler);
 
     g_free(handler->path);
     g_free(handler);

--- a/lib/formats/sh.c.in
+++ b/lib/formats/sh.c.in
@@ -114,7 +114,7 @@ static bool rm_sh_emit_handler_clone(RmFmtHandlerShScript *self, char **out, RmF
         *out = g_strdup_printf("clone '%s' '%s'", dupe_escaped, orig_escaped);
         return TRUE;
     default:
-        rm_assert_gentle_not_reached();
+        g_assert_not_reached();
         return FALSE;
     }
 }
@@ -148,7 +148,7 @@ static bool rm_sh_emit_handler_reflink(RmFmtHandlerShScript *self, char **out, R
         *out = g_strdup_printf("cp_reflink '%s' '%s'", dupe_escaped, orig_escaped);
         return TRUE;
     default:
-        rm_assert_gentle_not_reached();
+        g_assert_not_reached();
         return FALSE;
     }
 }

--- a/lib/hasher.c
+++ b/lib/hasher.c
@@ -93,12 +93,12 @@ static void rm_hasher_hashpipe_worker(RmBuffer *buffer, RmHasher *hasher) {
     g_assert(buffer);
     if(buffer->len > 0) {
         /* Update digest with buffer->data */
-        rm_assert_gentle(buffer->user_data == NULL);
+        g_assert(buffer->user_data == NULL);
         rm_digest_buffered_update(buffer);
     } else if(buffer->user_data) {
         /* finalise via callback */
         RmHasherTask *task = buffer->user_data;
-        rm_assert_gentle(task->digest == buffer->digest);
+        g_assert(task->digest == buffer->digest);
 
         g_assert(hasher);
         hasher->callback(hasher, task->digest, hasher->session_user_data,
@@ -389,7 +389,7 @@ RmHasher *rm_hasher_new(RmDigestType digest_type,
     /* Create a pool of hashing thread "pools" - each "pool" can only have
      * one thread because hashing must be done in order */
     self->hashpipe_pool = g_async_queue_new_full((GDestroyNotify)rm_hasher_hashpipe_free);
-    rm_assert_gentle(num_threads > 0);
+    g_assert(num_threads > 0);
     self->unalloc_hashpipes = num_threads;
     return self;
 }
@@ -444,7 +444,7 @@ RmHasherTask *rm_hasher_task_new(RmHasher *hasher, RmDigest *digest,
             self->hashpipe = g_async_queue_pop(hasher->hashpipe_pool);
         }
     }
-    rm_assert_gentle(self->hashpipe);
+    g_assert(self->hashpipe);
 
     self->task_user_data = task_user_data;
     return self;

--- a/lib/hasher.c
+++ b/lib/hasher.c
@@ -90,6 +90,7 @@ static void rm_hasher_task_free(RmHasherTask *self) {
 
 /* GThreadPool Worker for hashing */
 static void rm_hasher_hashpipe_worker(RmBuffer *buffer, RmHasher *hasher) {
+    g_assert(buffer);
     if(buffer->len > 0) {
         /* Update digest with buffer->data */
         rm_assert_gentle(buffer->user_data == NULL);
@@ -99,6 +100,7 @@ static void rm_hasher_hashpipe_worker(RmBuffer *buffer, RmHasher *hasher) {
         RmHasherTask *task = buffer->user_data;
         rm_assert_gentle(task->digest == buffer->digest);
 
+        g_assert(hasher);
         hasher->callback(hasher, task->digest, hasher->session_user_data,
                          task->task_user_data);
         rm_hasher_task_free(task);

--- a/lib/md-scheduler.c
+++ b/lib/md-scheduler.c
@@ -256,7 +256,7 @@ static void rm_mds_factory(RmMDSDevice *device, RmMDS *mds) {
  **/
 void rm_mds_device_start(RmMDSDevice *device, RmMDS *mds) {
     g_assert(device);
-    rm_assert_gentle(device->threads == 0);
+    g_assert(device->threads == 0);
 
     g_assert(mds);
     device->threads = mds->threads_per_disk;
@@ -288,7 +288,7 @@ static RmMDSDevice *rm_mds_device_get_by_disk(RmMDS *mds, const dev_t disk) {
     g_assert(mds);
     g_mutex_lock(&mds->lock);
     {
-        rm_assert_gentle(mds->disks);
+        g_assert(mds->disks);
 
         result = g_hash_table_lookup(mds->disks, GINT_TO_POINTER(disk));
         if(!result) {
@@ -335,7 +335,7 @@ void rm_mds_configure(RmMDS *self,
                       const gint threads_per_disk,
                       RmMDSSortFunc prioritiser) {
     g_assert(self);
-    rm_assert_gentle(self->running == FALSE);
+    g_assert(self->running == FALSE);
     self->func = func;
     self->user_data = user_data;
     self->threads_per_disk = threads_per_disk;

--- a/lib/md-scheduler.c
+++ b/lib/md-scheduler.c
@@ -255,8 +255,10 @@ static void rm_mds_factory(RmMDSDevice *device, RmMDS *mds) {
 /** @brief Push an RmMDSDevice to the threadpool
  **/
 void rm_mds_device_start(RmMDSDevice *device, RmMDS *mds) {
+    g_assert(device);
     rm_assert_gentle(device->threads == 0);
 
+    g_assert(mds);
     device->threads = mds->threads_per_disk;
     g_mutex_lock(&device->lock);
     {
@@ -283,6 +285,7 @@ void rm_mds_start(RmMDS *mds) {
 
 static RmMDSDevice *rm_mds_device_get_by_disk(RmMDS *mds, const dev_t disk) {
     RmMDSDevice *result = NULL;
+    g_assert(mds);
     g_mutex_lock(&mds->lock);
     {
         rm_assert_gentle(mds->disks);
@@ -331,6 +334,7 @@ void rm_mds_configure(RmMDS *self,
                       const gint pass_quota,
                       const gint threads_per_disk,
                       RmMDSSortFunc prioritiser) {
+    g_assert(self);
     rm_assert_gentle(self->running == FALSE);
     self->func = func;
     self->user_data = user_data;

--- a/lib/pathtricia.c
+++ b/lib/pathtricia.c
@@ -78,7 +78,7 @@ static RmNode *rm_node_insert(RmTrie *trie, RmNode *parent, const char *elem) {
 ///////////////////////////
 
 void rm_trie_init(RmTrie *self) {
-    rm_assert_gentle(self);
+    g_assert(self);
     self->root = rm_node_new(self, NULL);
 
     /* Average path len is 93.633236.
@@ -120,8 +120,8 @@ char *rm_path_iter_next(RmPathIter *iter) {
 }
 
 RmNode *rm_trie_insert(RmTrie *self, const char *path, void *value) {
-    rm_assert_gentle(self);
-    rm_assert_gentle(path);
+    g_assert(self);
+    g_assert(path);
 
     RmPathIter iter;
     rm_path_iter_init(&iter, path);
@@ -147,8 +147,8 @@ RmNode *rm_trie_insert(RmTrie *self, const char *path, void *value) {
 }
 
 RmNode *rm_trie_search_node(RmTrie *self, const char *path) {
-    rm_assert_gentle(self);
-    rm_assert_gentle(path);
+    g_assert(self);
+    g_assert(path);
 
     RmPathIter iter;
     rm_path_iter_init(&iter, path);

--- a/lib/preprocess.c
+++ b/lib/preprocess.c
@@ -500,8 +500,8 @@ static gboolean rm_pp_check_path_double(RmFile *file, GHashTable *unique_paths_t
         g_hash_table_add(unique_paths_table, key);
         return FALSE;
     }
-    RmFile *match_double = match_double_key->file;
-    rm_assert_gentle(match_double != file);
+
+    rm_assert_gentle(match_double_key->file != file);
 
     rm_path_double_free(key);
     rm_file_destroy(file);

--- a/lib/preprocess.c
+++ b/lib/preprocess.c
@@ -418,7 +418,7 @@ static int rm_pp_cmp_criterion(unsigned char criterion, const RmFile *a, const R
         return sign * cmp;
     }
     default:
-        rm_assert_gentle_not_reached();
+        g_assert_not_reached();
         return 0;
     }
 }
@@ -501,7 +501,7 @@ static gboolean rm_pp_check_path_double(RmFile *file, GHashTable *unique_paths_t
         return FALSE;
     }
 
-    rm_assert_gentle(match_double_key->file != file);
+    g_assert(match_double_key->file != file);
 
     rm_path_double_free(key);
     rm_file_destroy(file);
@@ -579,7 +579,7 @@ static gboolean rm_pp_handle_inode_clusters(_UNUSED gpointer key, GQueue *inode_
     /* update counters */
     rm_fmt_set_state(session->formats, RM_PROGRESS_STATE_PREPROCESS);
 
-    rm_assert_gentle(inode_cluster->length <= 1);
+    g_assert(inode_cluster->length <= 1);
     if(inode_cluster->length == 1) {
         session->tables->size_groups->data = g_slist_prepend(
             session->tables->size_groups->data, inode_cluster->head->data);
@@ -608,8 +608,8 @@ static RmOff rm_pp_handler_other_lint(const RmSession *session) {
         for(GList *iter = list; iter; iter = iter->next) {
             RmFile *file = iter->data;
 
-            rm_assert_gentle(file);
-            rm_assert_gentle(type == file->lint_type);
+            g_assert(file);
+            g_assert(type == file->lint_type);
 
             num_handled++;
 
@@ -650,7 +650,7 @@ void rm_preprocess(RmSession *session) {
 
     /* split into file size groups; for each size, remove path doubles and bundle
      * hardlinks */
-    rm_assert_gentle(all_files->head);
+    g_assert(all_files->head);
     RmFile *file = g_queue_pop_head(all_files);
     RmFile *current_size_file = file;
     guint removed = 0;

--- a/lib/replay.c
+++ b/lib/replay.c
@@ -213,7 +213,7 @@ static RmFile *rm_parrot_try_next(RmParrot *polly) {
     if(hardlink_of != NULL) {
         rm_file_hardlink_add(polly->last_original, file);
     } else {
-        rm_assert_gentle(!file->hardlinks);
+        g_assert(!file->hardlinks);
     }
 
     return file;

--- a/lib/session.c
+++ b/lib/session.c
@@ -298,7 +298,8 @@ int rm_session_dedupe_main(RmCfg *cfg) {
         } else if(dedupe.info.status == _DATA_DIFFERS) {
             if(dedupe_chunk != min_dedupe_chunk) {
                 dedupe_chunk = min_dedupe_chunk;
-                rm_log_debug_line("Dropping to %lu byte chunks after %lu bytes",
+                rm_log_debug_line("Dropping to %"G_GINT64_FORMAT"-byte chunks "
+                                  "after %"G_GINT64_FORMAT" bytes",
                                   dedupe_chunk, bytes_deduped);
                 continue;
             } else {
@@ -314,14 +315,15 @@ int rm_session_dedupe_main(RmCfg *cfg) {
 
         bytes_deduped += dedupe.info.bytes_deduped;
     }
-    rm_log_debug_line("Bytes deduped: %lu", bytes_deduped);
+    rm_log_debug_line("Bytes deduped: %"G_GINT64_FORMAT, bytes_deduped);
 
     if (ret!=0) {
         rm_log_perrorf(_("%s returned error: (%d)"), _DEDUPE_IOCTL_NAME, ret);
     } else if(bytes_deduped == 0) {
         rm_log_info_line(_("Files don't match - not deduped"));
     } else if(bytes_deduped < source_stat.st_size) {
-        rm_log_info_line(_("Only first %lu bytes deduped - files not fully identical"),
+        rm_log_info_line(_("Only first %"G_GINT64_FORMAT" bytes deduped "
+                           "- files not fully identical"),
                          bytes_deduped);
     }
 

--- a/lib/shredder.c
+++ b/lib/shredder.c
@@ -491,12 +491,14 @@ static RmShredGroup *rm_shred_group_new(RmFile *file) {
 
 /* Compute optimal size for next hash increment call this with group locked */
 static gint32 rm_shred_get_read_size(RmFile *file, RmShredTag *tag) {
+    g_assert(file);
     RmShredGroup *group = file->shred_group;
     rm_assert_gentle(group);
 
     gint32 result = 0;
 
     /* calculate next_offset property of the RmShredGroup */
+    g_assert(tag);
     RmOff balanced_bytes = tag->page_size * SHRED_BALANCED_PAGES;
     RmOff target_bytes = balanced_bytes * group->offset_factor;
     if(group->next_offset == 2) {
@@ -734,6 +736,7 @@ static void rm_shred_push_queue(RmFile *file) {
 /* Free RmShredGroup and any dormant files still in its queue
  */
 static void rm_shred_group_free(RmShredGroup *self, bool force_free) {
+    g_assert(self);
     rm_assert_gentle(self->parent == NULL); /* children should outlive their parents! */
     rm_assert_gentle(self->num_pending == 0);
 
@@ -1278,6 +1281,7 @@ static gboolean rm_shred_has_duplicates(GQueue *group) {
 }
 
 void rm_shred_forward_to_output(RmSession *session, GQueue *group) {
+    g_assert(session);
     rm_assert_gentle(group);
     rm_assert_gentle(group->head);
 
@@ -1338,7 +1342,8 @@ static RmShredGroup *rm_shred_create_rejects(RmShredGroup *group, RmFile *file) 
 static void rm_shred_group_transfer(RmFile *file, RmShredGroup *source,
                                     RmShredGroup *dest) {
     rm_shred_group_push_file(dest, file, FALSE);
-    rm_assert_gentle(g_queue_remove(source->held_files, file));
+    gboolean success = g_queue_remove(source->held_files, file);
+    rm_assert_gentle(success); (void)success;
     source->num_files--;
     source->n_pref -= file->is_prefd;
     source->n_npref -= !file->is_prefd;

--- a/lib/shredder.c
+++ b/lib/shredder.c
@@ -493,7 +493,7 @@ static RmShredGroup *rm_shred_group_new(RmFile *file) {
 static gint32 rm_shred_get_read_size(RmFile *file, RmShredTag *tag) {
     g_assert(file);
     RmShredGroup *group = file->shred_group;
-    rm_assert_gentle(group);
+    g_assert(group);
 
     gint32 result = 0;
 
@@ -551,7 +551,7 @@ static void rm_shred_mem_return(RmShredGroup *group) {
 #endif
             tag->mem_refusing = FALSE;
             if(group->digest) {
-                rm_assert_gentle(group->digest->type == RM_DIGEST_PARANOID);
+                g_assert(group->digest->type == RM_DIGEST_PARANOID);
                 rm_digest_free(group->digest);
                 group->digest = NULL;
             }
@@ -737,8 +737,8 @@ static void rm_shred_push_queue(RmFile *file) {
  */
 static void rm_shred_group_free(RmShredGroup *self, bool force_free) {
     g_assert(self);
-    rm_assert_gentle(self->parent == NULL); /* children should outlive their parents! */
-    rm_assert_gentle(self->num_pending == 0);
+    g_assert(self->parent == NULL); /* children should outlive their parents! */
+    g_assert(self->num_pending == 0);
 
     RmCfg *cfg = self->session->cfg;
 
@@ -769,7 +769,7 @@ static void rm_shred_group_free(RmShredGroup *self, bool force_free) {
         g_hash_table_unref(self->children);
     }
 
-    rm_assert_gentle(!self->in_progress_digests);
+    g_assert(!self->in_progress_digests);
 
     g_mutex_clear(&self->lock);
 
@@ -821,7 +821,7 @@ static void rm_shred_group_finalise(RmShredGroup *self) {
         break;
     case RM_SHRED_GROUP_FINISHED:
     default:
-        rm_assert_gentle_not_reached();
+        g_assert_not_reached();
     }
 }
 
@@ -898,7 +898,7 @@ static RmFile *rm_shred_group_push_file(RmShredGroup *shred_group, RmFile *file,
         shred_group->n_clusters++;
         shred_group->n_inodes += RM_FILE_INODE_COUNT(file);
 
-        rm_assert_gentle(file->hash_offset == shred_group->hash_offset);
+        g_assert(file->hash_offset == shred_group->hash_offset);
 
         rm_shred_group_update_status(shred_group);
         switch(shred_group->status) {
@@ -932,7 +932,7 @@ static RmFile *rm_shred_group_push_file(RmShredGroup *shred_group, RmFile *file,
             break;
         case RM_SHRED_GROUP_FINISHED:
         default:
-            rm_assert_gentle_not_reached();
+            g_assert_not_reached();
         }
     }
     g_mutex_unlock(&shred_group->lock);
@@ -951,9 +951,9 @@ static RmFile *rm_shred_sift(RmFile *file) {
     RmFile *result = NULL;
     gboolean current_group_finished = FALSE;
 
-    rm_assert_gentle(file);
+    g_assert(file);
     RmShredGroup *current_group = file->shred_group;
-    rm_assert_gentle(current_group);
+    g_assert(current_group);
 
     g_mutex_lock(&current_group->lock);
     {
@@ -972,7 +972,7 @@ static RmFile *rm_shred_sift(RmFile *file) {
             rm_shred_discard_file(file, true);
 
         } else {
-            rm_assert_gentle(file->digest);
+            g_assert(file->digest);
 
             /* check is child group hashtable has been created yet */
             if(current_group->children == NULL) {
@@ -1022,8 +1022,8 @@ static void rm_shred_hash_callback(_UNUSED RmHasher *hasher, RmDigest *digest,
     if(!file->digest) {
         file->digest = digest;
     }
-    rm_assert_gentle(file->digest == digest);
-    rm_assert_gentle(file->hash_offset == file->shred_group->next_offset);
+    g_assert(file->digest == digest);
+    g_assert(file->hash_offset == file->shred_group->next_offset);
 
     if(file->status != RM_FILE_STATE_IGNORE) {
         /* remember that checksum */
@@ -1063,8 +1063,8 @@ static void rm_shred_file_preprocess(RmFile *file, RmShredGroup **group) {
     RmShredTag *shredder = session->shredder;
     RmCfg *cfg = session->cfg;
 
-    rm_assert_gentle(file);
-    rm_assert_gentle(file->lint_type == RM_LINT_TYPE_DUPE_CANDIDATE);
+    g_assert(file);
+    g_assert(file->lint_type == RM_LINT_TYPE_DUPE_CANDIDATE);
 
     /* Create an empty checksum for empty files */
     if(file->file_size == 0) {
@@ -1128,8 +1128,8 @@ static gint rm_shred_cmp_ext_cksum(RmFile *a, RmFile *b) {
 }
 
 static void rm_shred_process_group(GSList *files, _UNUSED RmShredTag *main) {
-    rm_assert_gentle(files);
-    rm_assert_gentle(files->data);
+    g_assert(files);
+    g_assert(files->data);
 
     /* cluster hardlinks and ext_cksum matches;
      * Initially I over-complicated this until I realised that hardlinks
@@ -1282,8 +1282,8 @@ static gboolean rm_shred_has_duplicates(GQueue *group) {
 
 void rm_shred_forward_to_output(RmSession *session, GQueue *group) {
     g_assert(session);
-    rm_assert_gentle(group);
-    rm_assert_gentle(group->head);
+    g_assert(group);
+    g_assert(group->head);
 
 #if _RM_SHRED_DEBUG
     RmFile *head = group->head->data;
@@ -1343,7 +1343,7 @@ static void rm_shred_group_transfer(RmFile *file, RmShredGroup *source,
                                     RmShredGroup *dest) {
     rm_shred_group_push_file(dest, file, FALSE);
     gboolean success = g_queue_remove(source->held_files, file);
-    rm_assert_gentle(success); (void)success;
+    g_assert(success); (void)success;
     source->num_files--;
     source->n_pref -= file->is_prefd;
     source->n_npref -= !file->is_prefd;
@@ -1437,7 +1437,7 @@ static void rm_shred_group_postprocess(RmShredGroup *group, RmShredTag *tag) {
     }
     RmCfg *cfg = tag->session->cfg;
 
-    rm_assert_gentle(group->held_files);
+    g_assert(group->held_files);
 
     /* Features like --mtime-window require post processing, i.e. the shred group
      * needs to be split up further by criteria like "mtime difference too high".
@@ -1562,7 +1562,7 @@ static bool rm_shred_reassign_checksum(RmShredTag *main, RmFile *file) {
             if(group->next_offset == 0) {
                 (void)rm_shred_get_read_size(file, main);
             }
-            rm_assert_gentle(group->hash_offset == file->hash_offset);
+            g_assert(group->hash_offset == file->hash_offset);
         }
         g_mutex_unlock(&group->lock);
 
@@ -1694,8 +1694,8 @@ static gint rm_shred_process_file(RmFile *file, RmSession *session) {
 }
 
 void rm_shred_run(RmSession *session) {
-    rm_assert_gentle(session);
-    rm_assert_gentle(session->tables);
+    g_assert(session);
+    g_assert(session->tables);
 
     RmCfg *cfg = session->cfg;
 

--- a/lib/treemerge.c
+++ b/lib/treemerge.c
@@ -416,9 +416,9 @@ static guint rm_directory_hash(const RmDirectory *d) {
 }
 
 static void rm_directory_add(RmTreeMerger *self, RmDirectory *directory, RmFile *file) {
-    rm_assert_gentle(file);
-    rm_assert_gentle(file->digest);
-    rm_assert_gentle(directory);
+    g_assert(file);
+    g_assert(file->digest);
+    g_assert(directory);
 
     guint8 *file_digest = NULL;
     RmOff digest_bytes = 0;

--- a/lib/utilities.c
+++ b/lib/utilities.c
@@ -421,7 +421,7 @@ RmUserList *rm_userlist_new(void) {
 
 bool rm_userlist_contains(RmUserList *self, unsigned long uid, unsigned gid,
                           bool *valid_uid, bool *valid_gid) {
-    rm_assert_gentle(self);
+    g_assert(self);
     bool gid_found = FALSE;
     bool uid_found = FALSE;
 
@@ -446,7 +446,7 @@ bool rm_userlist_contains(RmUserList *self, unsigned long uid, unsigned gid,
 }
 
 void rm_userlist_destroy(RmUserList *self) {
-    rm_assert_gentle(self);
+    g_assert(self);
 
     g_sequence_free(self->users);
     g_sequence_free(self->groups);
@@ -547,7 +547,7 @@ typedef struct RmMountEntries {
 } RmMountEntries;
 
 static void rm_mount_list_close(RmMountEntries *self) {
-    rm_assert_gentle(self);
+    g_assert(self);
 
     for(GList *iter = self->entries; iter; iter = iter->next) {
         RmMountEntry *entry = iter->data;
@@ -563,7 +563,7 @@ static void rm_mount_list_close(RmMountEntries *self) {
 }
 
 static RmMountEntry *rm_mount_list_next(RmMountEntries *self) {
-    rm_assert_gentle(self);
+    g_assert(self);
 
     if(self->current) {
         self->current = self->current->next;
@@ -952,7 +952,7 @@ bool rm_mounts_is_evil(RmMountTable *self, dev_t to_check) {
 }
 
 bool rm_mounts_can_reflink(RmMountTable *self, dev_t source, dev_t dest) {
-    rm_assert_gentle(self);
+    g_assert(self);
     if(g_hash_table_contains(self->reflinkfs_table, GUINT_TO_POINTER(source))) {
         if(source == dest) {
             return true;
@@ -961,8 +961,8 @@ bool rm_mounts_can_reflink(RmMountTable *self, dev_t source, dev_t dest) {
                 g_hash_table_lookup(self->part_table, GINT_TO_POINTER(source));
             RmPartitionInfo *dest_part =
                 g_hash_table_lookup(self->part_table, GINT_TO_POINTER(dest));
-            rm_assert_gentle(source_part);
-            rm_assert_gentle(dest_part);
+            g_assert(source_part);
+            g_assert(dest_part);
             return (strcmp(source_part->fsname, dest_part->fsname) == 0);
         }
     } else {

--- a/lib/xattr.c
+++ b/lib/xattr.c
@@ -86,6 +86,7 @@ static int rm_xattr_build_key(RmSession *session,
     rm_assert_gentle(session);
 
     /* Be safe, assume caller is not concentrated. */
+    g_assert(buf);
     memset(buf, 0, sizeof(buf_size));
 
     const char *digest_name = rm_digest_type_to_string(session->cfg->checksum_type);
@@ -93,6 +94,7 @@ static int rm_xattr_build_key(RmSession *session,
         digest_name = rm_digest_type_to_string(RM_DEFAULT_DIGEST);
     }
 
+    g_assert(suffix);
     return snprintf(buf, buf_size, "user.rmlint.%s.%s", digest_name, suffix) < 0;
 }
 
@@ -100,6 +102,7 @@ static int rm_xattr_build_cksum(RmFile *file, char *buf, size_t buf_size) {
     rm_assert_gentle(file);
     rm_assert_gentle(file->digest);
 
+    g_assert(buf);
     memset(buf, '0', buf_size);
     buf[buf_size - 1] = 0;
 

--- a/lib/xattr.c
+++ b/lib/xattr.c
@@ -83,7 +83,7 @@ static int rm_xattr_build_key(RmSession *session,
                               const char *suffix,
                               char *buf,
                               size_t buf_size) {
-    rm_assert_gentle(session);
+    g_assert(session);
 
     /* Be safe, assume caller is not concentrated. */
     g_assert(buf);
@@ -99,8 +99,8 @@ static int rm_xattr_build_key(RmSession *session,
 }
 
 static int rm_xattr_build_cksum(RmFile *file, char *buf, size_t buf_size) {
-    rm_assert_gentle(file);
-    rm_assert_gentle(file->digest);
+    g_assert(file);
+    g_assert(file->digest);
 
     g_assert(buf);
     memset(buf, '0', buf_size);
@@ -153,9 +153,9 @@ static int rm_xattr_del(RmFile *file, const char *key) {
 ////////////////////////////
 
 int rm_xattr_write_hash(RmFile *file, RmSession *session) {
-    rm_assert_gentle(file);
-    rm_assert_gentle(file->digest);
-    rm_assert_gentle(session);
+    g_assert(file);
+    g_assert(file->digest);
+    g_assert(session);
 
 #if HAVE_XATTR
     if(file->ext_cksum || session->cfg->write_cksum_to_xattr == false) {
@@ -181,8 +181,8 @@ int rm_xattr_write_hash(RmFile *file, RmSession *session) {
 }
 
 gboolean rm_xattr_read_hash(RmFile *file, RmSession *session) {
-    rm_assert_gentle(file);
-    rm_assert_gentle(session);
+    g_assert(file);
+    g_assert(session);
 
 #if HAVE_XATTR
     if(session->cfg->read_cksum_from_xattr == false) {
@@ -224,8 +224,8 @@ gboolean rm_xattr_read_hash(RmFile *file, RmSession *session) {
 }
 
 int rm_xattr_clear_hash(RmFile *file, RmSession *session) {
-    rm_assert_gentle(file);
-    rm_assert_gentle(session);
+    g_assert(file);
+    g_assert(session);
 
 #if HAVE_XATTR
     int error = 0;


### PR DESCRIPTION
This series fixes some issues that are causing compiler warnings, and it also potentially avoids some run-time bugs; one subtle bug could eventually arise if *all* debug assertions were elided, because its argument is not just a declaration of some condition, but rather an important call with side effects.

Here's a quick summary of the patches:
1. SConstruct: Use `-Wno-cast-function-type' only if GCC's major version >= 8
2. lib/session.c: dedupe: Format strings with `G_GINT64_FORMAT'
3. C: Fix up asserts
4. C: Remove the `rm_assert_gentle*()' macros