### PR TITLE
Inline the abort functions

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -40,7 +40,7 @@ def check_gcc_version(context):
     context.Message('Checking for GCC version... ')
 
     try:
-        v = subprocess.check_output("printf '%s\n' __GNUC__ | gcc -E - | tail -n -1", shell=True)
+        v = subprocess.check_output("printf '%s\n' __GNUC__ | gcc -E -P -", shell=True)
         try:
             v = int(v)
             context.Result(str(v))

--- a/SConstruct
+++ b/SConstruct
@@ -675,6 +675,7 @@ conf.env.Append(CFLAGS=[
     '-Wuninitialized',
     '-Wstrict-prototypes',
     '-Wno-implicit-fallthrough',
+    '-Winline'
 ])
 
 env.ParseConfig(pkg_config + ' --cflags --libs ' + ' '.join(packages))

--- a/lib/config.h.in
+++ b/lib/config.h.in
@@ -169,4 +169,20 @@ typedef guint64 RmOff;
 /* Domain for reporting errors. Needed by GOptions */
 #define RM_ERROR_QUARK (g_quark_from_static_string("rmlint"))
 
+#ifndef RM_DEBUG
+    #ifdef __GNUC__
+        #define INLINE inline __attribute__((__always_inline__))
+    #elif defined(__CLANG__)
+        #if __has_attribute(__always_inline__)
+            #define INLINE inline __attribute__((__always_inline__))
+        #endif
+    #elif defined(_MSC_VER)
+        #define INLINE __forceinline
+    #endif
+#endif
+
+#ifndef INLINE
+    #define INLINE inline
+#endif
+
 #endif

--- a/lib/session.h
+++ b/lib/session.h
@@ -31,8 +31,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-/* Needed for RmTreeMerger */
-#include "treemerge.h"
+#include "config.h"     // INLINE
+#include "treemerge.h"  // RmTreeMerger
 
 typedef struct RmFileTables {
     /* List of all files found during traversal */
@@ -157,7 +157,7 @@ void rm_session_clear(RmSession *session);
  *
  * Threadsafe.
  */
-static inline void rm_session_abort(void) {
+static INLINE void rm_session_abort(void) {
     extern volatile int rm_session_abort_count;
     g_atomic_int_add(&rm_session_abort_count, 1);
 }
@@ -167,7 +167,7 @@ static inline void rm_session_abort(void) {
  *
  * Threadsafe.
  */
-static inline bool rm_session_was_aborted(void) {
+static INLINE bool rm_session_was_aborted(void) {
     extern volatile int rm_session_abort_count;
     const gint n = g_atomic_int_get(&rm_session_abort_count);
 

--- a/lib/session.h
+++ b/lib/session.h
@@ -157,14 +157,27 @@ void rm_session_clear(RmSession *session);
  *
  * Threadsafe.
  */
-void rm_session_abort(void);
+static inline void rm_session_abort(void) {
+    extern volatile int rm_session_abort_count;
+    g_atomic_int_add(&rm_session_abort_count, 1);
+}
 
 /**
  * @brief Check if rmlint was aborted early.
  *
  * Threadsafe.
  */
-bool rm_session_was_aborted(void);
+static inline bool rm_session_was_aborted(void) {
+    extern volatile int rm_session_abort_count;
+    const gint n = g_atomic_int_get(&rm_session_abort_count);
+
+    if (n) {
+        void rm_session_acknowledge_abort(gint);
+        rm_session_acknowledge_abort(n);
+    }
+
+    return n;
+}
 
 /**
  * @brief Check the kernel version of the Linux kernel.

--- a/po/de.po
+++ b/po/de.po
@@ -354,12 +354,12 @@ msgid "Can't get real path for directory or file \"%s\": %s"
 msgstr "Kann Verzeichnis oder Datei \"%s\" nicht öffnen: %s"
 
 #: lib/session.c:142
-msgid "Received Interrupt, stopping..."
-msgstr "Wurde unterbrochen, ich höre auf..."
+msgid "Received interrupt; stopping..."
+msgstr "Wurde unterbrochen; ich höre auf..."
 
 #: lib/session.c:156
-msgid "Received second Interrupt, stopping hard."
-msgstr "Wurde nochmal unterbrochen, mache sofort Schluss."
+msgid "Received second interrupt; stopping hard."
+msgstr "Wurde nochmal unterbrochen; mache sofort Schluss."
 
 #: lib/formats.c:219
 #, c-format

--- a/po/es.po
+++ b/po/es.po
@@ -350,12 +350,12 @@ msgid "Can't get real path for directory or file \"%s\": %s"
 msgstr "No se puede abrir el directorio o archivo \"%s\": %s"
 
 #: lib/session.c:142
-msgid "Received Interrupt, stopping..."
-msgstr "Interrupción Recibida, deteniendo..."
+msgid "Received interrupt; stopping..."
+msgstr "Interrupción Recibida; deteniendo..."
 
 #: lib/session.c:156
-msgid "Received second Interrupt, stopping hard."
-msgstr "Segunda Interrupción Recibida, deteniendo firmemente."
+msgid "Received second interrupt; stopping hard."
+msgstr "Segunda Interrupción Recibida; deteniendo firmemente."
 
 #: lib/formats.c:219
 #, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -348,12 +348,12 @@ msgid "Can't get real path for directory or file \"%s\": %s"
 msgstr "Impossible d'ouvrir le répertoire ou le fichier \"%s\": %s\n"
 
 #: lib/session.c:142
-msgid "Received Interrupt, stopping..."
-msgstr "Interruption demandée, arrêt..."
+msgid "Received interrupt; stopping..."
+msgstr "Interruption demandée; arrêt..."
 
 #: lib/session.c:156
-msgid "Received second Interrupt, stopping hard."
-msgstr "Seconde interruption demandée, arrêt brutal"
+msgid "Received second interrupt; stopping hard."
+msgstr "Seconde interruption demandée; arrêt brutal"
 
 #: lib/formats.c:219
 #, c-format

--- a/po/rmlint.pot
+++ b/po/rmlint.pot
@@ -345,11 +345,11 @@ msgid "Can't get real path for directory or file \"%s\": %s"
 msgstr ""
 
 #: lib/session.c:142
-msgid "Received Interrupt, stopping..."
+msgid "Received interrupt; stopping..."
 msgstr ""
 
 #: lib/session.c:156
-msgid "Received second Interrupt, stopping hard."
+msgid "Received second interrupt; stopping hard."
 msgstr ""
 
 #: lib/formats.c:219


### PR DESCRIPTION
This series cleans up and inlines the following functions:

* `rm_session_abort()`
* `rm_session_was_aborted()`

The warning messages produced by the latter (including the translations) have also undergone a minor cleanup with regard to punctuation and capitalization.

Also, this series introduces a portable means by which to force the compiler to inline a function.