### PR TITLE
Update and ease support of gettext translations

### DIFF
--- a/docs/translators.rst
+++ b/docs/translators.rst
@@ -71,19 +71,11 @@ translated during compile time. You have to mark them first and translate them a
        printf("World is %s\n", _(stuff));
    }
 
-After you're done with marking the new strings, you have to update the template:
+After you're done with marking the new strings, you have to update the
+gettext files:
 
 .. code-block:: bash
 
-   # scons can do this for you already:
-   $ scons xgettext
+   $ scons gettext
 
-You need to add the new strings to the existing translations now:
-
-.. code-block:: bash
-
-   $ msgmerge po/de.po po/rmlint.pot > po/de_new.po
-   $ EDITOR po/de_new.po   # check if everything was merged alright.
-   $ mv po/de_new.po po/de.po
-
-After that you can translate the new strings and proceed like in the upper steps.
+Then, proceed to work with the relevant `*.po` file as described above.

--- a/po/SConscript
+++ b/po/SConscript
@@ -35,6 +35,8 @@ def xgettext(target=None, source=None, env=None):
     Exit(subprocess.call(
         'xgettext --package-name rmlint -k_ -kN_ ' \
         '--package-version {}.{}.{} --default-domain rmlint ' \
+        '--add-location=file ' \
+        '--join-existing ' \
         '--output po/rmlint.pot ' \
         '--from-code UTF-8 ' \
         '$(find src lib -iname "*.[ch]") &&' \

--- a/po/SConscript
+++ b/po/SConscript
@@ -7,7 +7,6 @@ Import('VERSION_MAJOR')
 Import('VERSION_MINOR')
 Import('VERSION_PATCH')
 
-
 import os
 import subprocess
 
@@ -31,8 +30,8 @@ if env['HAVE_MSGFMT']:
             create_uninstall_target(env, path)
 
 
-def xgettext(target=None, source=None, env=None):
-    Exit(subprocess.call(
+def xgettext():
+    return subprocess.call(
         'xgettext --package-name rmlint -k_ -kN_ ' \
         '--package-version {}.{}.{} --default-domain rmlint ' \
         '--add-location=file ' \
@@ -46,11 +45,58 @@ def xgettext(target=None, source=None, env=None):
             VERSION_PATCH
         ),
         shell=True
-    ))
+    )
+
+
+def xgettext_action(target=None, source=None, env=None):
+    status = xgettext()
+    if status:
+        print('Error: xgettext failed')
+        Exit(status)
+
+
+def msgmerge(target=None, source=None, env=None):
+    return subprocess.call(
+        'set -e;' \
+        'for p in po/*.po; do' \
+        '  msgmerge --update --backup=none "$p" po/rmlint.pot;' \
+        'done',
+        shell=True
+    )
+
+
+def msgmerge_action(target=None, source=None, env=None):
+    status = msgmerge()
+    if status:
+        print('Error: msgmerge failed')
+        Exit(status)
+
+
+def gettext_action(target=None, source=None, env=None):
+    status = xgettext()
+    if status:
+        ('Error: gettext failed while running xgettext')
+        Exit(status)
+    status = msgmerge()
+    if status:
+        print('Error: gettext failed while running msgmerge')
+        Exit(status)
 
 
 if 'xgettext' in COMMAND_LINE_TARGETS:
     env.Alias(
         'xgettext',
-        env.Command('xgettext', None, Action(xgettext, "Running xgettext"))
+        env.Command('xgettext', None, Action(xgettext_action, "Running xgettext"))
+    )
+
+if 'msgmerge' in COMMAND_LINE_TARGETS:
+    env.Alias(
+        'msgmerge',
+        env.Command('msgmerge', None, Action(msgmerge_action, "Running msgmerge"))
+    )
+
+if 'gettext' in COMMAND_LINE_TARGETS:
+    env.Alias(
+        'gettext',
+        env.Command('gettext', None, Action(gettext_action, "Running gettext"))
     )

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rmlint 2.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-03 22:16+0200\n"
+"POT-Creation-Date: 2018-09-27 22:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,99 +16,99 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/rmlint.c:78
+#: src/rmlint.c
 #, c-format
 msgid "Aborting due to a fatal error. (signal received: %s)"
 msgstr "Abbruch aufgrund eines fatalen Fehlers (exaktes Signal: %s)"
 
-#: src/rmlint.c:80
+#: src/rmlint.c
 msgid "Please file a bug report (See rmlint -h)"
 msgstr "Mache bitte einen Bugreport auf (Mehr Infos unter man rmlint)"
 
-#: lib/formats/pretty.c:34
+#: lib/formats/pretty.c
 msgid "Bad symlink(s)"
 msgstr "Falsche Symlink(s)"
 
-#: lib/formats/pretty.c:35
+#: lib/formats/pretty.c
 msgid "Empty dir(s)"
 msgstr "Leere Verzeichnisse"
 
-#: lib/formats/pretty.c:36
+#: lib/formats/pretty.c
 msgid "Non stripped binarie(s)"
 msgstr "Programme mit Debuginformation(en)"
 
-#: lib/formats/pretty.c:37
+#: lib/formats/pretty.c
 msgid "Bad UID(s)"
 msgstr "Falsche UID(s)"
 
-#: lib/formats/pretty.c:38
+#: lib/formats/pretty.c
 msgid "Bad GID(s)"
 msgstr "Falsche GID(s)"
 
-#: lib/formats/pretty.c:39
+#: lib/formats/pretty.c
 msgid "Bad UID and GID(s)"
 msgstr "Falsche UID und GID(s)"
 
-#: lib/formats/pretty.c:40
+#: lib/formats/pretty.c
 msgid "Empty file(s)"
 msgstr "Leere Dateien"
 
-#: lib/formats/pretty.c:41
+#: lib/formats/pretty.c
 msgid "Duplicate(s)"
 msgstr "Duplikate"
 
-#: lib/formats/pretty.c:42
+#: lib/formats/pretty.c
 msgid "Duplicate Directorie(s)"
 msgstr "Doppelte Verzeichnisse"
 
-#: lib/formats/summary.c:54
+#: lib/formats/summary.c
 #, fuzzy, c-format
 msgid " file(s) after investigation, nothing to search through.\n"
 msgstr " Dateien nach dem Traversieren; nichts zum durchsuchen.\n"
 
-#: lib/formats/summary.c:69
+#: lib/formats/summary.c
 #, c-format
 msgid "Early shutdown, probably not all lint was found.\n"
 msgstr "Früher Abbruch, vermutlich wurde nicht alles gefunden.\n"
 
-#: lib/formats/summary.c:74
+#: lib/formats/summary.c
 #, c-format
 msgid ""
 "Note: Please use the saved script below for removal, not the above output."
 msgstr ""
 "Beachte: Bitte benutze das Skript unten zum Löschen, nicht die Ausgabe."
 
-#: lib/formats/summary.c:87
+#: lib/formats/summary.c
 #, c-format
 msgid "In total %s files, whereof %s are duplicates in %s groups.\n"
 msgstr "Insgesamt %s Dateien, von denen %s Duplikate in %s Gruppen sind.\n"
 
-#: lib/formats/summary.c:95
+#: lib/formats/summary.c
 #, c-format
 msgid "This equals %s%s%s of duplicates which could be removed.\n"
 msgstr "Dies entspricht %s%s%s an Duplikaten die entfernt werden können.\n"
 
-#: lib/formats/summary.c:102
+#: lib/formats/summary.c
 #, c-format
 msgid "other suspicious item(s) found, which may vary in size.\n"
 msgstr "andere merkwürdige Datei(en) gefunden, die in ihrer Größe variieren.\n"
 
-#: lib/formats/summary.c:107
+#: lib/formats/summary.c
 #, c-format
 msgid "Scanning took in total %s%s%s. Is that good enough?\n"
 msgstr "Das ganze hat %s%s%s gedauert. War das ausreichend schnell?\n"
 
-#: lib/formats/summary.c:143
+#: lib/formats/summary.c
 #, c-format
 msgid "Wrote a %s%s%s file to: %s%s%s\n"
 msgstr "Eine %s%s%s Datei wurde nach %s%s%s geschrieben.\n"
 
-#: lib/formats/stats.c:52
+#: lib/formats/stats.c
 #, c-format
 msgid "No shred stats.\n"
 msgstr "Keine Statistiken verfügbar.\n"
 
-#: lib/formats/stats.c:71
+#: lib/formats/stats.c
 #, c-format
 msgid ""
 "%sDuplicate finding stats (includes hardlinks):%s\n"
@@ -117,293 +117,293 @@ msgstr ""
 "%sDuplikat Statistiken (enthält Hardlinks):%s\n"
 "\n"
 
-#: lib/formats/stats.c:75
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s bytes of originals\n"
 msgstr "%s%15s%s Originalbytes\n"
 
-#: lib/formats/stats.c:79
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s bytes of duplicates\n"
 msgstr "%s%15s%s Duplikatbytes\n"
 
-#: lib/formats/stats.c:83
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s bytes of non-duplicates\n"
 msgstr "%s%15s%s Nicht-Duplikatbytes\n"
 
-#: lib/formats/stats.c:87
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s bytes of files data actually read\n"
 msgstr "%s%15s%s gelesene Bytes insgesamt\n"
 
-#: lib/formats/stats.c:90
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15d%s Files in total\n"
 msgstr "%s%15d%s Dateien insgesamt\n"
 
-#: lib/formats/stats.c:92
+#: lib/formats/stats.c
 #, fuzzy, c-format
 msgid "%s%15ld%s Duplicate files\n"
 msgstr "%s%15ld%s Doppelte Dateien\n"
 
-#: lib/formats/stats.c:94
+#: lib/formats/stats.c
 #, fuzzy, c-format
 msgid "%s%15ld%s Groups in total\n"
 msgstr "%s%15ld%s Dateien insgesamt\n"
 
-#: lib/formats/stats.c:96
+#: lib/formats/stats.c
 #, fuzzy, c-format
 msgid "%s%15ld%s Other lint items\n"
 msgstr "%s%15ld%s Andere seltsame Dateien\n"
 
-#: lib/formats/stats.c:104
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s of time spent scanning\n"
 msgstr "%s%15s%s Zeitaufwand zum Scannen\n"
 
-#: lib/formats/stats.c:122
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s Algorithm efficiency on total files basis\n"
 msgstr "%s%15s%s Algorithmus-Effizienz auf Basis aller Dateien\n"
 
-#: lib/formats/stats.c:124
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s Algorithm efficiency on duplicate file basis\n"
 msgstr "%s%15s%s Algorithmus-Effizienz auf Basis doppelter Dateien\n"
 
-#: lib/formats/progressbar.c:76
+#: lib/formats/progressbar.c
 msgid "reduces files to"
 msgstr "reduziere Dateien zu"
 
-#: lib/formats/progressbar.c:134
+#: lib/formats/progressbar.c
 msgid "Traversing"
 msgstr "Traversiere"
 
-#: lib/formats/progressbar.c:135
+#: lib/formats/progressbar.c
 msgid "usable files"
 msgstr "nutzbare Dateien"
 
-#: lib/formats/progressbar.c:138
+#: lib/formats/progressbar.c
 msgid "ignored files / folders"
 msgstr "ignorierte Dateien / Verzeichnisse"
 
-#: lib/formats/progressbar.c:145
+#: lib/formats/progressbar.c
 msgid "Preprocessing"
 msgstr "Bereite vor"
 
 # No translation needed / Translated
-#: lib/formats/progressbar.c:145
+#: lib/formats/progressbar.c
 msgid "found"
 msgstr "fand"
 
-#: lib/formats/progressbar.c:146
+#: lib/formats/progressbar.c
 msgid "other lint"
 msgstr "mal anderen Unsinn"
 
-#: lib/formats/progressbar.c:166
+#: lib/formats/progressbar.c
 msgid "Matching"
 msgstr "Gleiche ab"
 
-#: lib/formats/progressbar.c:167
+#: lib/formats/progressbar.c
 msgid "dupes of"
 msgstr "Duplikate von"
 
-#: lib/formats/progressbar.c:168
+#: lib/formats/progressbar.c
 msgid "originals"
 msgstr "Originalen"
 
-#: lib/formats/progressbar.c:170
+#: lib/formats/progressbar.c
 msgid "to scan in"
 msgstr "zum Scannen in"
 
-#: lib/formats/progressbar.c:171
+#: lib/formats/progressbar.c
 msgid "files"
 msgstr "Dateien"
 
-#: lib/formats/progressbar.c:180
+#: lib/formats/progressbar.c
 msgid "Merging files into directories (stand by...)"
 msgstr "Führe doppelte Dateien in doppelte Verzeichnisse zusammen..."
 
-#: lib/formats/sh.c:546
+#: lib/formats/sh.c
 #, c-format
 msgid "%s is an invalid handler."
 msgstr "%s ist eine ungültiger Handler"
 
-#: lib/hasher.c:310
+#: lib/hasher.c
 #, fuzzy, c-format
 msgid "Something went wrong reading %s; expected %li bytes, got %li; ignoring"
 msgstr ""
 "Irgendwas lief falsch beim Lesen von %s; habe %d Bytes erwartet, bekam %d. "
 "Datei wird ignoriert."
 
-#: lib/utilities.c:315
+#: lib/utilities.c
 #, c-format
 msgid "cannot open file '%s' for nonstripped test: "
 msgstr "Kann Datei %s nicht öffnen um zu sehen ob sie Debugsymbole hat."
 
-#: lib/utilities.c:322
+#: lib/utilities.c
 msgid "ELF Library is out of date!"
 msgstr "ELF Bibliothek ist extrem veraltet!"
 
-#: lib/utilities.c:662
+#: lib/utilities.c
 #, fuzzy, c-format
 msgid "`%s` mount detected at %s (#%u); Ignoring all files in it.\n"
 msgstr ""
 "`%s` Einhängepunkt gefunden (zeigt auf %s, #%u). Ignoriere alle Dateien "
 "darin."
 
-#: lib/preprocess.c:236
+#: lib/preprocess.c
 msgid "Pattern has to start with `<`"
 msgstr "Muster muss mmit `<` beginnen"
 
-#: lib/preprocess.c:264
+#: lib/preprocess.c
 #, c-format
 msgid "`<` or `>` imbalance: %d"
 msgstr "`<` oder `>` unbalanciert: %d"
 
-#: lib/preprocess.c:271
+#: lib/preprocess.c
 msgid "empty pattern"
 msgstr "Leeres Muster"
 
-#: lib/preprocess.c:313
+#: lib/preprocess.c
 msgid "no pattern given in <> after 'r' or 'x'"
 msgstr "Kein Muster in <> gegeben, obwohl 'r' oder 'x' benutzt wurde"
 
-#: lib/preprocess.c:329
+#: lib/preprocess.c
 #, fuzzy, c-format
 msgid "Cannot add more than %lu regex patterns."
 msgstr "Kann nicht mehr als %ld Muster hinzufügen."
 
-#: lib/preprocess.c:341
+#: lib/preprocess.c
 msgid "Error while parsing sortcriteria patterns: "
 msgstr "Fehler beim parsen der Muster im Sortierkriterium: "
 
-#: lib/replay.c:107
+#: lib/replay.c
 msgid "No valid json cache (no array in /)"
 msgstr "Kein valider JSON Cache. (u.a. weil kein [] vorhanden)"
 
 # #: lib/cmdline.c:551
 # #, c-format
-#: lib/replay.c:154 lib/cmdline.c:729
+#: lib/replay.c lib/cmdline.c
 #, c-format
 msgid "lint type '%s' not recognised"
 msgstr "Typ \"%s\" nicht erkannt"
 
-#: lib/replay.c:181
+#: lib/replay.c
 #, c-format
 msgid "modification time of `%s` changed. Ignoring."
 msgstr "mtime Zeitstempel von `%s` hat sich geändert. Ignoriere Datei."
 
-#: lib/replay.c:486
+#: lib/replay.c
 #, fuzzy, c-format
 msgid "Loading json-results `%s'"
 msgstr "Lade JSON Cache: `%s'"
 
-#: lib/replay.c:597
+#: lib/replay.c
 msgid "json-glib is needed for using --replay."
 msgstr "json-glib wird zur Benutzung von `--replay` benötigt."
 
-#: lib/replay.c:598
+#: lib/replay.c
 msgid "Please recompile `rmlint` with it installed."
 msgstr "Bitte kompilieren Sie `rmlint` entsprechend neu."
 
-#: lib/traverse.c:318
+#: lib/traverse.c
 #, c-format
 msgid "filesystem loop detected at %s (skipping)"
 msgstr "Dateisystemschleife entdeckt: %s (wird übersprungen)"
 
-#: lib/traverse.c:323
+#: lib/traverse.c
 #, c-format
 msgid "cannot read directory %s: %s"
 msgstr "Kann Verzeichnis %s nicht lesen: %s"
 
-#: lib/traverse.c:336
+#: lib/traverse.c
 #, c-format
 msgid "error %d in fts_read for %s (skipping)"
 msgstr "Fehler #%d in fts_read für %s (Überspringe...)"
 
-#: lib/traverse.c:365
+#: lib/traverse.c
 #, c-format
 msgid "Added big file %s"
 msgstr "Füge sehr große Datei hinzu %s"
 
-#: lib/traverse.c:367
+#: lib/traverse.c
 #, c-format
 msgid "cannot stat file %s (skipping)"
 msgstr "Kann stat(2) nicht auf Datei %s aufrufen (überspringe)"
 
-#: lib/traverse.c:414
+#: lib/traverse.c
 #, c-format
 msgid "Unknown fts_info flag %d for file %s"
 msgstr "Unbekanntes fts_info flag %d für Datei %s"
 
-#: lib/traverse.c:434
+#: lib/traverse.c
 #, c-format
 msgid "'%s': fts_read failed on %s"
 msgstr "'%s': fts_read schlug fehl bei Pfad %s"
 
-#: lib/cfg.c:99 lib/hash-utility.c:227
+#: lib/cfg.c lib/hash-utility.c
 #, c-format
 msgid "Can't open directory or file \"%s\": %s"
 msgstr "Kann Verzeichnis oder Datei \"%s\" nicht öffnen: %s"
 
-#: lib/cfg.c:106
+#: lib/cfg.c
 #, fuzzy, c-format
 msgid "Can't get real path for directory or file \"%s\": %s"
 msgstr "Kann Verzeichnis oder Datei \"%s\" nicht öffnen: %s"
 
-#: lib/session.c:142
+#: lib/session.c
 msgid "Received interrupt; stopping..."
 msgstr "Wurde unterbrochen; ich höre auf..."
 
-#: lib/session.c:156
+#: lib/session.c
 msgid "Received second interrupt; stopping hard."
 msgstr "Wurde nochmal unterbrochen; mache sofort Schluss."
 
-#: lib/formats.c:219
+#: lib/formats.c
 #, c-format
 msgid "No such new_handler with this name: %s"
 msgstr "Kein Formathandler mit diesen Namen: %s"
 
-#: lib/formats.c:249
+#: lib/formats.c
 #, c-format
 msgid "Unable to open file for writing: %s"
 msgstr "Kann Datei nicht zum lesen öffnen: %s"
 
-#: lib/hash-utility.c:56 lib/cmdline.c:904
+#: lib/hash-utility.c lib/cmdline.c
 #, c-format
 msgid "Unknown hash algorithm: '%s'"
 msgstr "Unbekannte Hashfunktion: \"%s\""
 
-#: lib/hash-utility.c:139
+#: lib/hash-utility.c
 msgid "Digest type [BLAKE2B]"
 msgstr "Prüfsummentyp [BLAKE2B]"
 
-#: lib/hash-utility.c:140
+#: lib/hash-utility.c
 msgid "Number of hashing threads [8]"
 msgstr "Anzahl der Hashing Threads [8]"
 
-#: lib/hash-utility.c:142
+#: lib/hash-utility.c
 msgid "Megabytes read buffer [256 MB]"
 msgstr "Größe des Lesepuffers [256 MB]"
 
-#: lib/hash-utility.c:143
+#: lib/hash-utility.c
 msgid ""
 "Print hashes in order completed, not in order entered (reduces memory usage)"
 msgstr ""
 "Zeige die Hashes in der Fertigstellungs-Reihenfolge, nicht in Eingabe-"
 "Reihenfolge (braucht weniger RAM)"
 
-#: lib/hash-utility.c:144
+#: lib/hash-utility.c
 msgid "Space-separated list of files"
 msgstr "Leerzeichen-separierte Liste von Dateien"
 
-#: lib/hash-utility.c:150 lib/hash-utility.c:152
+#: lib/hash-utility.c
 msgid "Hash a list of files"
 msgstr "Hashe eine Liste von Dateien"
 
-#: lib/hash-utility.c:158
+#: lib/hash-utility.c
 #, c-format
 msgid ""
 "Multi-threaded file digest (hash) calculator.\n"
@@ -428,27 +428,27 @@ msgstr ""
 "  Unterstützt aber ziemlich sinnfrei:\n"
 "    %s\n"
 
-#: lib/hash-utility.c:194
+#: lib/hash-utility.c
 #, fuzzy
 msgid "No valid paths given"
 msgstr "Keine validen Pfade gegeben."
 
-#: lib/hash-utility.c:230
+#: lib/hash-utility.c
 #, c-format
 msgid "Directories are not supported: %s"
 msgstr "Verzeichnisse werden nicht unterstützt: %s"
 
-#: lib/hash-utility.c:239
+#: lib/hash-utility.c
 #, c-format
 msgid "%s: Unknown file type"
 msgstr "%s: Unbekannter Dateityp"
 
-#: lib/cmdline.c:79
+#: lib/cmdline.c
 #, c-format
 msgid "compiled with:"
 msgstr "kompiliert mit:"
 
-#: lib/cmdline.c:85
+#: lib/cmdline.c
 #, c-format
 msgid ""
 "rmlint was written by Christopher <sahib> Pahl and Daniel <SeeSpotRun> "
@@ -457,7 +457,7 @@ msgstr ""
 "rmlint wurde von Christopher <sahib> Pahl und Daniel <SeeSpotRun> Thomas "
 "geschrieben."
 
-#: lib/cmdline.c:88
+#: lib/cmdline.c
 #, c-format
 msgid ""
 "The code at https://github.com/sahib/rmlint is licensed under the terms of "
@@ -466,36 +466,36 @@ msgstr ""
 "Der Quelltext unter https://github.com/sahib/rmlint ist unter den "
 "Bedingungen der GPLv3 lizenziert"
 
-#: lib/cmdline.c:113
+#: lib/cmdline.c
 msgid "You seem to have no manpage for rmlint."
 msgstr "Scheinbar hast du keine Manpage für rmlint."
 
-#: lib/cmdline.c:114
+#: lib/cmdline.c
 msgid "Please run rmlint --help to show the regular help."
 msgstr "Bitte führe `rmlint --help` aus, um die reguläre Hilfe zu sehen"
 
-#: lib/cmdline.c:116
+#: lib/cmdline.c
 msgid ""
 "Alternatively, visit https://rmlint.rtfd.org for the online documentation"
 msgstr ""
 "Alternativ, kann man https://rmlint.rtfd.org für eine detailreichere "
 "Dokumentation besuchen"
 
-#: lib/cmdline.c:237
+#: lib/cmdline.c
 #, fuzzy
 msgid "Usage: rmlint --dedupe [-r] source dest\n"
 msgstr "Benutzung: rmlint --dedupe QUELLE ZIEL\n"
 
-#: lib/cmdline.c:251
+#: lib/cmdline.c lib/session.c
 msgid "dedupe: failed to open source file"
 msgstr "dedupe: Konnte Quelldatei nicht öffnen"
 
-#: lib/cmdline.c:257
+#: lib/cmdline.c lib/session.c
 #, fuzzy, c-format
 msgid "dedupe: error %i: failed to open dest file.%s"
 msgstr "dedupe: Konnte Zieldatei nicht öffnen"
 
-#: lib/cmdline.c:259
+#: lib/cmdline.c lib/session.c
 msgid ""
 "\n"
 "\t(if target is a read-only snapshot then -r option is required)"
@@ -503,316 +503,316 @@ msgstr ""
 "\n"
 "\t(wenn das Ziel ein read-only snapshot ist, muss -r benutzt werden)"
 
-#: lib/cmdline.c:295
+#: lib/cmdline.c
 #, c-format
 msgid "BTRFS_IOC_FILE_EXTENT_SAME returned error: (%d) %s"
 msgstr "BTRFS_IOC_FILE_EXTENT_SAME gab Fehler zurück: (%d) %s"
 
-#: lib/cmdline.c:298
+#: lib/cmdline.c
 msgid "Need to run as root user to clone to a read-only snapshot"
 msgstr ""
 "Muss als root Nutzer gestartet werden, um einen read-only Snapshot zu clonen"
 
-#: lib/cmdline.c:300
+#: lib/cmdline.c
 #, c-format
 msgid "BTRFS_IOC_FILE_EXTENT_SAME returned status %d for file %s"
 msgstr "BTRFS_IOC_FILE_EXTENT_SAME gab den Status %d für die Datei %s zurück"
 
-#: lib/cmdline.c:303
+#: lib/cmdline.c
 msgid "Files don't match - not cloned"
 msgstr "Dateien sind nicht gleich - nichts geklont"
 
-#: lib/cmdline.c:309
+#: lib/cmdline.c
 msgid "rmlint was not compiled with btrfs support."
 msgstr "rmlint wurde nicht mit `btrfs` Unterstützung kompiliert"
 
-#: lib/cmdline.c:370
+#: lib/cmdline.c
 msgid "Input size is empty"
 msgstr "Eingabegröße ist leer. Nicht gut."
 
-#: lib/cmdline.c:378
+#: lib/cmdline.c
 msgid "This does not look like a number"
 msgstr "Das schaut nicht wie eine Zahl aus"
 
-#: lib/cmdline.c:381
+#: lib/cmdline.c
 msgid "Negativ sizes are no good idea"
 msgstr "Negative Größen sind keine gute Idee"
 
-#: lib/cmdline.c:397
+#: lib/cmdline.c
 msgid "Given format specifier not found"
 msgstr "Gegebene Formatangabe ist unbekannt"
 
-#: lib/cmdline.c:429
+#: lib/cmdline.c
 msgid "Max is smaller than min"
 msgstr "Maximum ist kleiner als das Minimum. Macht leider keinen Sinn"
 
-#: lib/cmdline.c:441
+#: lib/cmdline.c
 msgid "cannot parse --size: "
 msgstr "Kann --size nicht parsen: "
 
-#: lib/cmdline.c:497
+#: lib/cmdline.c
 #, fuzzy, c-format
 msgid "Adding -o %s as output failed"
 msgstr "Konnte -o %s nicht als Ausgabe hinzufügen"
 
-#: lib/cmdline.c:509
+#: lib/cmdline.c
 #, fuzzy, c-format
 msgid "No format (format:key[=val]) specified in '%s'"
 msgstr "Kein Format (format:key[=val]) gegeben in '%s'"
 
-#: lib/cmdline.c:519
+#: lib/cmdline.c
 #, fuzzy, c-format
 msgid "Missing key (format:key[=val]) in '%s'"
 msgstr "Fehlender Key (format:key[=val]) in '%s'"
 
-#: lib/cmdline.c:534
+#: lib/cmdline.c
 #, fuzzy, c-format
 msgid "Invalid key `%s' for formatter `%s'"
 msgstr "Ungültiger Konfigschlüssel `%s` für den Formatter `%s`"
 
-#: lib/cmdline.c:561
+#: lib/cmdline.c
 #, c-format
 msgid "Unable to parse factor \"%s\": error begins at %s"
 msgstr "Konnte nicht den Faktor \"%s\" parsen: Fehler beginnt bei %s"
 
-#: lib/cmdline.c:571
+#: lib/cmdline.c
 #, c-format
 msgid "factor value is not in range [0-1]: %f"
 msgstr "Faktorwert liegt nicht im Bereich [0-1]: %f"
 
-#: lib/cmdline.c:583
+#: lib/cmdline.c
 #, fuzzy, c-format
 msgid "Unable to parse offset \"%s\": "
 msgstr "Kann Offset nicht parsen \"%s\": "
 
-#: lib/cmdline.c:778
+#: lib/cmdline.c
 #, c-format
 msgid "Unable to parse time spec \"%s\""
 msgstr "Kann Zeitangabe nicht parsen: \"%s\""
 
-#: lib/cmdline.c:792
+#: lib/cmdline.c
 #, c-format
 msgid "-n %lu is newer than current time (%lu)."
 msgstr "-n %lu ist neuer als jetzt (%lu) - ist das korrekt?"
 
-#: lib/cmdline.c:881
+#: lib/cmdline.c
 #, fuzzy
 msgid "Only up to -pp or down to -PP flags allowed"
 msgstr "Maximal zwei -p flags oder zwei -P Flag erlaubt"
 
-#: lib/cmdline.c:933
+#: lib/cmdline.c
 #, fuzzy, c-format
 msgid "Invalid size description \"%s\": "
 msgstr "Fehlerhafte Größenangabe \"%s\": "
 
-#: lib/cmdline.c:1125
+#: lib/cmdline.c
 msgid "Permissions string needs to be one or many of [rwx]"
 msgstr "Zugriffsrechte werden durch Kombinationen aus [rwx] ausgedrückt"
 
-#: lib/cmdline.c:1138
+#: lib/cmdline.c
 #, c-format
 msgid "%s may only contain [%s], not `%c`"
 msgstr "%s darf nur einen Buchstaben aus [%s] enthalten, aber doch nicht `%c`"
 
-#: lib/cmdline.c:1263
+#: lib/cmdline.c
 #, fuzzy
 msgid "Specifiyng both -o and -O is not allowed"
 msgstr "Gleichzeitige Angabe von -o und -O ist nicht möglich"
 
-#: lib/cmdline.c:1283
+#: lib/cmdline.c
 msgid "Could not start graphical user interface."
 msgstr "Konnte graphische Oberfläche nicht starten."
 
-#: lib/cmdline.c:1314
+#: lib/cmdline.c
 msgid "Specify max traversal depth"
 msgstr "Gibt die maximale Traversierungstiefe an"
 
-#: lib/cmdline.c:1315
+#: lib/cmdline.c
 #, fuzzy
 msgid "Select originals by given  criteria"
 msgstr "Gibt das Original Kriterium an"
 
-#: lib/cmdline.c:1316
+#: lib/cmdline.c
 #, fuzzy
 msgid "Sort rmlint output by given criteria"
 msgstr "Ordne Gruppe nach einem bestimmten Kriterium"
 
-#: lib/cmdline.c:1317
+#: lib/cmdline.c
 msgid "Specify lint types"
 msgstr "Gibt an welche Art von Dateien gesucht werden"
 
-#: lib/cmdline.c:1318
+#: lib/cmdline.c
 msgid "Specify size limits"
 msgstr "Angabe der Größenbeschränkungen"
 
-#: lib/cmdline.c:1319
+#: lib/cmdline.c
 #, fuzzy
 msgid "Choose hash algorithm"
 msgstr "Wähle die Hashfunktion"
 
-#: lib/cmdline.c:1320
+#: lib/cmdline.c
 msgid "Add output (override default)"
 msgstr "Output hinzufügen (überschreibt die Standardoutputs)"
 
-#: lib/cmdline.c:1321
+#: lib/cmdline.c
 msgid "Add output (add to defaults)"
 msgstr "Output hinzufügen (fügt zu den Standardoutputs hinzu)"
 
-#: lib/cmdline.c:1322
+#: lib/cmdline.c
 msgid "Newer than stamp file"
 msgstr "Suche nur Dateien die neuer sind als Datum in der .stamp Datei"
 
-#: lib/cmdline.c:1323
+#: lib/cmdline.c
 msgid "Newer than timestamp"
 msgstr "Suchen nur Dateien die neuer sind als der Timestamp"
 
-#: lib/cmdline.c:1324
+#: lib/cmdline.c
 msgid "Configure a formatter"
 msgstr "Setze Werte für einen Formatter"
 
-#: lib/cmdline.c:1327
+#: lib/cmdline.c
 msgid "Enable progressbar"
 msgstr "Zeige Fortschrittsbalken"
 
-#: lib/cmdline.c:1328
+#: lib/cmdline.c
 msgid "Be more verbose (-vvv for much more)"
 msgstr "Sei gesprächiger (-vvv für Quasselstrippe)"
 
-#: lib/cmdline.c:1329
+#: lib/cmdline.c
 msgid "Be less verbose (-VVV for much less)"
 msgstr "Sei weniger gesprächig (-VVV für Totenstille)"
 
-#: lib/cmdline.c:1330
+#: lib/cmdline.c
 msgid "Re-output a json file"
 msgstr "Gebe json Datei erneut aus"
 
-#: lib/cmdline.c:1331
+#: lib/cmdline.c
 msgid "Test for equality of PATHS"
 msgstr "Teste die Gleichheit von der Pfade PATHS"
 
-#: lib/cmdline.c:1334
+#: lib/cmdline.c
 msgid "Be not that colorful"
 msgstr "Sei nicht farbenfroh"
 
-#: lib/cmdline.c:1335
+#: lib/cmdline.c
 msgid "Find hidden files"
 msgstr "Finde versteckte Dateien"
 
-#: lib/cmdline.c:1336
+#: lib/cmdline.c
 #, fuzzy
 msgid "Follow symlinks"
 msgstr "Folge symbolischen Links"
 
-#: lib/cmdline.c:1337
+#: lib/cmdline.c
 #, fuzzy
 msgid "Ignore symlinks"
 msgstr "Ignoriere symbolische Links"
 
-#: lib/cmdline.c:1338
+#: lib/cmdline.c
 msgid "Use more paranoid hashing"
 msgstr "Benutze immer paranoideren Hashalgorithmus"
 
-#: lib/cmdline.c:1339
+#: lib/cmdline.c
 msgid "Do not cross mounpoints"
 msgstr "Überquere keine Mountpoints"
 
-#: lib/cmdline.c:1340
+#: lib/cmdline.c
 msgid "Keep all tagged files"
 msgstr "Behalte alle markierten Dateien"
 
-#: lib/cmdline.c:1341
+#: lib/cmdline.c
 msgid "Keep all untagged files"
 msgstr "Behalte alle unmarkierten Dateien"
 
-#: lib/cmdline.c:1342
+#: lib/cmdline.c
 msgid "Must have twin in tagged dir"
 msgstr "Duplikat braucht einen Zwilling im markierten Verzeichnis"
 
-#: lib/cmdline.c:1343
+#: lib/cmdline.c
 msgid "Must have twin in untagged dir"
 msgstr "Duplikat braucht einen Zwilling im unmarkierten Verzeichnis"
 
-#: lib/cmdline.c:1344
+#: lib/cmdline.c
 msgid "Only find twins with same basename"
 msgstr "Finde nur Duplikate mit selben Dateinamen"
 
-#: lib/cmdline.c:1345
+#: lib/cmdline.c
 msgid "Only find twins with same extension"
 msgstr "Finde nur Duplikate mit selber Dateiendung"
 
-#: lib/cmdline.c:1346
+#: lib/cmdline.c
 msgid "Only find twins with same basename minus extension"
 msgstr "Finde nur Duplikate mit Dateinamen minus der Endung"
 
-#: lib/cmdline.c:1347
+#: lib/cmdline.c
 #, fuzzy
 msgid "Find duplicate directories"
 msgstr "Finde doppelte Verzeichnisse"
 
-#: lib/cmdline.c:1348
+#: lib/cmdline.c
 #, fuzzy
 msgid "Only find directories with same file layout"
 msgstr "Finde nur Duplikate mit selben Dateinamen"
 
-#: lib/cmdline.c:1349
+#: lib/cmdline.c
 msgid "Only use files with certain permissions"
 msgstr "Betrachte nur Dateien mit gewissen Zugriffsrechten"
 
-#: lib/cmdline.c:1350
+#: lib/cmdline.c
 #, fuzzy
 msgid "Ignore hardlink twins"
 msgstr "Ignoriere Hardlinks"
 
-#: lib/cmdline.c:1351
+#: lib/cmdline.c
 msgid "Find hidden files in duplicate folders only"
 msgstr "Finde versteckte Dateien nur in doppelten Verzeichnissen"
 
-#: lib/cmdline.c:1352
+#: lib/cmdline.c
 msgid "Consider duplicates only equal when mtime differs at max. T seconds"
 msgstr ""
 "Betrachte Duplikate nur als gleich wenn die mtime sich maximal T Sekunden "
 "unterscheidet"
 
-#: lib/cmdline.c:1355
+#: lib/cmdline.c
 msgid "Show the manpage"
 msgstr "Zeige das volle Handbuch"
 
-#: lib/cmdline.c:1356
+#: lib/cmdline.c
 msgid "Show the version & features"
 msgstr "Zeige die Version & alle einkompilierten Features"
 
-#: lib/cmdline.c:1358
+#: lib/cmdline.c
 msgid "If installed, start the optional gui with all following args"
 msgstr "Falls installiert, starte die optionale grafische Oberfläche"
 
-#: lib/cmdline.c:1359
+#: lib/cmdline.c
 msgid ""
 "Work like sha1sum for all supported hash algorithms (see also --hash --help)"
 msgstr ""
 "Funktioniere wie sha1sum für alle unterstützten Hashsummen (siehe auch --"
 "hash --help)"
 
-#: lib/cmdline.c:1360
+#: lib/cmdline.c
 msgid "Clone extents from source to dest, if extents match"
 msgstr "Klone Extents von Quell zu Zieldatei falls sie übereinstimmen"
 
-#: lib/cmdline.c:1370
+#: lib/cmdline.c
 msgid "Report hardlinks as duplicates"
 msgstr "Zeige Hardlinks als Duplikate an"
 
-#: lib/cmdline.c:1416
+#: lib/cmdline.c
 msgid "Cannot set current working directory"
 msgstr "Kann aktuelles Arbeitsverzeichnis nicht setzen"
 
-#: lib/cmdline.c:1421
+#: lib/cmdline.c
 msgid "Cannot join commandline"
 msgstr "Kann Kommandozeilenargumente nicht auslesen. (huh?)"
 
-#: lib/cmdline.c:1432
+#: lib/cmdline.c
 msgid "[TARGET_DIR_OR_FILES …] [//] [TAGGED_TARGET_DIR_OR_FILES …] [-]"
 msgstr "[ZIEL_ORDERN_ODER_DATEIEN …] [//] [ZIEL_ORDERN_ODER_DATEIEN …] [-]"
 
-#: lib/cmdline.c:1450
+#: lib/cmdline.c
 msgid ""
 "rmlint finds space waste and other broken things on your filesystem and "
 "offers to remove it.\n"
@@ -824,7 +824,7 @@ msgstr ""
 "Es ist besonders gut darin Duplikate zu erkennen und bietet eine große "
 "Palette an Möglichkeiten an, um sie loszuwerden."
 
-#: lib/cmdline.c:1456
+#: lib/cmdline.c
 msgid ""
 "Only the most important options and options that alter the defaults are "
 "shown above.\n"
@@ -840,58 +840,176 @@ msgstr ""
 "Online-version des Manuals.\n"
 "Zudem gibt es unter http://rmlint.rtfd.org Einsteigerinformationen."
 
-#: lib/cmdline.c:1487
+#: lib/cmdline.c
 msgid ""
 "--honour-dir-layout (-j) makes no sense without --merge-directories (-D)"
-msgstr "--honour-dir-layout (-j) macht wenig Sinn ohne --merge-directories (-D)"
+msgstr ""
+"--honour-dir-layout (-j) macht wenig Sinn ohne --merge-directories (-D)"
 
-#: lib/cmdline.c:1512
+#: lib/cmdline.c
 #, fuzzy
 msgid "can't specify both --keep-all-tagged and --keep-all-untagged"
 msgstr ""
 "Kann nicht gleichzeitig --keep-all-tagged und --keep-all-untagged annehmen"
 
-#: lib/cmdline.c:1515
+#: lib/cmdline.c
 #, fuzzy
 msgid "-q (--clamp-low) should be lower than -Q (--clamp-top)"
 msgstr "-q (--clamp-low) sollte kleiner sein als -Q (--clamp-top)!"
 
-#: lib/cmdline.c:1517
+#: lib/cmdline.c
 msgid "Not all given paths are valid. Aborting"
 msgstr "Nicht alle angegebenen Pfade sind valid. Breche ab."
 
-#: lib/cmdline.c:1558
+#: lib/cmdline.c
 #, fuzzy
 msgid "No valid .json files given, aborting."
 msgstr "Kein valider JSON Cache. (u.a. weil kein [] vorhanden)"
 
-#: lib/cmdline.c:1612
+#: lib/cmdline.c
 msgid "Using -D together with -c sh:clone is currently not possible. Sorry."
-msgstr "Die Nutzung von -D mit -c sh:clone ist derzeit nicht möglich. Entschuldigung."
+msgstr ""
+"Die Nutzung von -D mit -c sh:clone ist derzeit nicht möglich. Entschuldigung."
 
-#: lib/cmdline.c:1613
+#: lib/cmdline.c
 msgid "Either do not use -D, or attempt to run again with -Dj."
 msgstr "Benutze entweder nicht -D oder versuche es mit -Dj erneut."
 
-#: lib/cmdline.c:1621
+#: lib/cmdline.c
 msgid "Not enough files for --equal (need at least two to compare)"
 msgstr "Nicht ausreichend viele Dateien für --equal (braucht mindestens zwei)"
 
-#: lib/config.h:115
+#: lib/config.h
 msgid "ERROR"
 msgstr "FEHLER"
 
-#: lib/config.h:120
+#: lib/config.h
 msgid "WARNING"
 msgstr "WARNUNG"
 
-#: lib/config.h:125
+#: lib/config.h
 msgid "INFO"
 msgstr "INFO"
 
-#: lib/config.h:130
+#: lib/config.h
 msgid "DEBUG"
 msgstr "DEBUG"
+
+#: lib/hash-utility.c
+msgid "bytes to hash at a time [4096]"
+msgstr ""
+
+#: lib/hash-utility.c
+#, fuzzy, c-format
+msgid ""
+"Multi-threaded file digest (hash) calculator.\n"
+"\n"
+"  Available digest types:\n"
+"  Cryptographic:\n"
+"    %s\n"
+"\n"
+"  Non-cryptographic:\n"
+"    %s\n"
+"\n"
+"  Supported, but not useful:\n"
+"    %s\n"
+msgstr ""
+"Paralleler Prüfsummen-Berechner für Dateien.\n"
+"\n"
+"  Verfügbare Hashsummentypen sind:\n"
+"    %s\n"
+"\n"
+"  Versionen mit unterschiedlicher Anzahl von Bits:\n"
+"    %s\n"
+"\n"
+"  Unterstützt aber ziemlich sinnfrei:\n"
+"    %s\n"
+
+#: lib/formats.c
+#, c-format
+msgid "Old result `%s` already exists."
+msgstr ""
+
+#: lib/formats.c
+#, c-format
+msgid "Moving old file to `%s`. Use --no-backup to disable this."
+msgstr ""
+
+#: lib/formats.c
+#, fuzzy
+msgid "failed to rename old result file"
+msgstr "dedupe: Konnte Quelldatei nicht öffnen"
+
+#: lib/session.c
+#, fuzzy
+msgid "Usage: rmlint --dedupe [-r] [-v|V] source dest\n"
+msgstr "Benutzung: rmlint --dedupe QUELLE ZIEL\n"
+
+#: lib/session.c
+#, c-format
+msgid "%s returned error: (%d)"
+msgstr ""
+
+#: lib/session.c
+#, fuzzy
+msgid "Files don't match - not deduped"
+msgstr "Dateien sind nicht gleich - nichts geklont"
+
+#: lib/session.c
+msgid "Only first %"
+msgstr ""
+
+#: lib/session.c
+#, fuzzy
+msgid "rmlint was not compiled with file cloning support."
+msgstr "rmlint wurde nicht mit `btrfs` Unterstützung kompiliert"
+
+#: lib/session.c
+#, fuzzy
+msgid "Usage: rmlint --is-clone [-v|V] file1 file2\n"
+msgstr "Benutzung: rmlint --dedupe QUELLE ZIEL\n"
+
+#: lib/cmdline.c
+#, fuzzy, c-format
+msgid "Only up to -%.*s or down to -%.*s flags allowed"
+msgstr "Maximal zwei -p flags oder zwei -P Flag erlaubt"
+
+#: lib/cmdline.c
+msgid "Keep hardlink that are linked to any original"
+msgstr ""
+
+#: lib/cmdline.c
+msgid "Read null-separated file list from stdin"
+msgstr ""
+
+#: lib/cmdline.c
+msgid "Do not create backups of previous result files"
+msgstr ""
+
+#: lib/cmdline.c
+#, fuzzy
+msgid "Dedupe matching extents from source to dest (if filesystem supports)"
+msgstr "Klone Extents von Quell zu Zieldatei falls sie übereinstimmen"
+
+#: lib/cmdline.c
+msgid "(--dedupe option) even dedupe read-only snapshots (needs root)"
+msgstr ""
+
+#: lib/cmdline.c
+msgid "Test if two files are reflinks (share same data extents)"
+msgstr ""
+
+#: lib/cmdline.c
+msgid ""
+"-k and -M should not be specified at the same time (see also: https://github."
+"com/sahib/rmlint/issues/244)"
+msgstr ""
+
+#: lib/cmdline.c
+msgid ""
+"-K and -m should not be specified at the same time (see also: https://github."
+"com/sahib/rmlint/issues/244)"
+msgstr ""
 
 #~ msgid "%s%15"
 #~ msgstr "%s%15"

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rmlint 2.4.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-03 22:16+0200\n"
+"POT-Creation-Date: 2018-09-27 22:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,62 +17,62 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/rmlint.c:78
+#: src/rmlint.c
 #, c-format
 msgid "Aborting due to a fatal error. (signal received: %s)"
 msgstr "Abortando debido a un error fatal. (señal recibida: %s)"
 
-#: src/rmlint.c:80
+#: src/rmlint.c
 msgid "Please file a bug report (See rmlint -h)"
 msgstr "Por favor presente un reporte de error (Ver rmlint -h)"
 
-#: lib/formats/pretty.c:34
+#: lib/formats/pretty.c
 msgid "Bad symlink(s)"
 msgstr "Enlace(s) simbólico(s) incorrecto(s)"
 
-#: lib/formats/pretty.c:35
+#: lib/formats/pretty.c
 msgid "Empty dir(s)"
 msgstr "Directorio(s) vacío(s)"
 
-#: lib/formats/pretty.c:36
+#: lib/formats/pretty.c
 msgid "Non stripped binarie(s)"
 msgstr "Binario(s) sin depurar"
 
-#: lib/formats/pretty.c:37
+#: lib/formats/pretty.c
 msgid "Bad UID(s)"
 msgstr "UID(s) incorrecta(s)"
 
-#: lib/formats/pretty.c:38
+#: lib/formats/pretty.c
 msgid "Bad GID(s)"
 msgstr "GID(s) incorrecta(s)"
 
-#: lib/formats/pretty.c:39
+#: lib/formats/pretty.c
 msgid "Bad UID and GID(s)"
 msgstr "UID y GID(s) incorrecta(s)"
 
-#: lib/formats/pretty.c:40
+#: lib/formats/pretty.c
 msgid "Empty file(s)"
 msgstr "Archivo(s) vacío(s)"
 
-#: lib/formats/pretty.c:41
+#: lib/formats/pretty.c
 msgid "Duplicate(s)"
 msgstr "Duplicado(s)"
 
-#: lib/formats/pretty.c:42
+#: lib/formats/pretty.c
 msgid "Duplicate Directorie(s)"
 msgstr "Directorio(s) duplicado(s)"
 
-#: lib/formats/summary.c:54
+#: lib/formats/summary.c
 #, c-format
 msgid " file(s) after investigation, nothing to search through.\n"
 msgstr "archivo(s) después de investigar, nada que buscar.\n"
 
-#: lib/formats/summary.c:69
+#: lib/formats/summary.c
 #, c-format
 msgid "Early shutdown, probably not all lint was found.\n"
 msgstr "Apagado prematuro, probablemente no toda la pelusa fué encontrada.\n"
 
-#: lib/formats/summary.c:74
+#: lib/formats/summary.c
 #, c-format
 msgid ""
 "Note: Please use the saved script below for removal, not the above output."
@@ -80,326 +80,326 @@ msgstr ""
 "Nota: Por favor use el script guardado abajo para eliminar, no la respuesta "
 "de arriba."
 
-#: lib/formats/summary.c:87
+#: lib/formats/summary.c
 #, c-format
 msgid "In total %s files, whereof %s are duplicates in %s groups.\n"
 msgstr "En total %s archivos, en donde %s son duplicados en %s grupos.\n"
 
-#: lib/formats/summary.c:95
+#: lib/formats/summary.c
 #, c-format
 msgid "This equals %s%s%s of duplicates which could be removed.\n"
 msgstr "Esto equivale a %s%s%s de duplicados lo cual podría ser eliminado.\n"
 
-#: lib/formats/summary.c:102
+#: lib/formats/summary.c
 #, c-format
 msgid "other suspicious item(s) found, which may vary in size.\n"
 msgstr ""
 "otro(s) artículo(s) sospechoso(s) encontrado(s), los cuales podrían variar "
 "en tamaño.\n"
 
-#: lib/formats/summary.c:107
+#: lib/formats/summary.c
 #, c-format
 msgid "Scanning took in total %s%s%s. Is that good enough?\n"
 msgstr ""
 
-#: lib/formats/summary.c:143
+#: lib/formats/summary.c
 #, c-format
 msgid "Wrote a %s%s%s file to: %s%s%s\n"
 msgstr "Escribió un archivo %s%s%s a: %s%s%s\n"
 
-#: lib/formats/stats.c:52
+#: lib/formats/stats.c
 #, c-format
 msgid "No shred stats.\n"
 msgstr ""
 
-#: lib/formats/stats.c:71
+#: lib/formats/stats.c
 #, c-format
 msgid ""
 "%sDuplicate finding stats (includes hardlinks):%s\n"
 "\n"
 msgstr ""
 
-#: lib/formats/stats.c:75
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s bytes of originals\n"
 msgstr ""
 
-#: lib/formats/stats.c:79
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s bytes of duplicates\n"
 msgstr ""
 
-#: lib/formats/stats.c:83
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s bytes of non-duplicates\n"
 msgstr ""
 
-#: lib/formats/stats.c:87
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s bytes of files data actually read\n"
 msgstr ""
 
-#: lib/formats/stats.c:90
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15d%s Files in total\n"
 msgstr ""
 
-#: lib/formats/stats.c:92
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15ld%s Duplicate files\n"
 msgstr ""
 
-#: lib/formats/stats.c:94
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15ld%s Groups in total\n"
 msgstr ""
 
-#: lib/formats/stats.c:96
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15ld%s Other lint items\n"
 msgstr ""
 
-#: lib/formats/stats.c:104
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s of time spent scanning\n"
 msgstr ""
 
-#: lib/formats/stats.c:122
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s Algorithm efficiency on total files basis\n"
 msgstr ""
 
-#: lib/formats/stats.c:124
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s Algorithm efficiency on duplicate file basis\n"
 msgstr ""
 
-#: lib/formats/progressbar.c:76
+#: lib/formats/progressbar.c
 msgid "reduces files to"
 msgstr "reduce los archivos a"
 
-#: lib/formats/progressbar.c:134
+#: lib/formats/progressbar.c
 msgid "Traversing"
 msgstr "Cruzando"
 
-#: lib/formats/progressbar.c:135
+#: lib/formats/progressbar.c
 msgid "usable files"
 msgstr "archivos usables"
 
-#: lib/formats/progressbar.c:138
+#: lib/formats/progressbar.c
 msgid "ignored files / folders"
 msgstr "archivos ignorados / carpetas"
 
-#: lib/formats/progressbar.c:145
+#: lib/formats/progressbar.c
 msgid "Preprocessing"
 msgstr "Procesando"
 
-#: lib/formats/progressbar.c:145
+#: lib/formats/progressbar.c
 msgid "found"
 msgstr "encontrado"
 
-#: lib/formats/progressbar.c:146
+#: lib/formats/progressbar.c
 msgid "other lint"
 msgstr "otra pelusa"
 
-#: lib/formats/progressbar.c:166
+#: lib/formats/progressbar.c
 msgid "Matching"
 msgstr "Cotejando"
 
-#: lib/formats/progressbar.c:167
+#: lib/formats/progressbar.c
 msgid "dupes of"
 msgstr "duplicados de"
 
-#: lib/formats/progressbar.c:168
+#: lib/formats/progressbar.c
 msgid "originals"
 msgstr "originales"
 
-#: lib/formats/progressbar.c:170
+#: lib/formats/progressbar.c
 msgid "to scan in"
 msgstr "para escanear en"
 
-#: lib/formats/progressbar.c:171
+#: lib/formats/progressbar.c
 msgid "files"
 msgstr "archivos"
 
-#: lib/formats/progressbar.c:180
+#: lib/formats/progressbar.c
 msgid "Merging files into directories (stand by...)"
 msgstr "Combinando archivos en directorios (espere...)"
 
-#: lib/formats/sh.c:546
+#: lib/formats/sh.c
 #, c-format
 msgid "%s is an invalid handler."
 msgstr "%s es un gestor inválido"
 
-#: lib/hasher.c:310
+#: lib/hasher.c
 #, c-format
 msgid "Something went wrong reading %s; expected %li bytes, got %li; ignoring"
 msgstr "Algo falló leyendo %s; esperados %li bytes, obtenidos %li; ignorando"
 
-#: lib/utilities.c:315
+#: lib/utilities.c
 #, c-format
 msgid "cannot open file '%s' for nonstripped test: "
 msgstr "no se puede abrir archivo '%s' para prueba sin depurar: "
 
-#: lib/utilities.c:322
+#: lib/utilities.c
 msgid "ELF Library is out of date!"
 msgstr "La Librería ELF está fuera de fecha!"
 
-#: lib/utilities.c:662
+#: lib/utilities.c
 #, c-format
 msgid "`%s` mount detected at %s (#%u); Ignoring all files in it.\n"
 msgstr ""
 "Montaje '%s' detectado en %s (#%u); Ignorando todos los archivos en él.\n"
 
-#: lib/preprocess.c:236
+#: lib/preprocess.c
 msgid "Pattern has to start with `<`"
 msgstr "El patrón debe empezar con `<`"
 
-#: lib/preprocess.c:264
+#: lib/preprocess.c
 #, c-format
 msgid "`<` or `>` imbalance: %d"
 msgstr "`<` o `>` desequilibran: %d"
 
-#: lib/preprocess.c:271
+#: lib/preprocess.c
 msgid "empty pattern"
 msgstr "patrón vacío"
 
-#: lib/preprocess.c:313
+#: lib/preprocess.c
 msgid "no pattern given in <> after 'r' or 'x'"
 msgstr ""
 
-#: lib/preprocess.c:329
+#: lib/preprocess.c
 #, fuzzy, c-format
 msgid "Cannot add more than %lu regex patterns."
 msgstr "No se puede añadir mas de %ld patrones de expresiones regulares"
 
-#: lib/preprocess.c:341
+#: lib/preprocess.c
 msgid "Error while parsing sortcriteria patterns: "
 msgstr "Error al analizar los patrones sortcriteria (criterio de órden)"
 
-#: lib/replay.c:107
+#: lib/replay.c
 msgid "No valid json cache (no array in /)"
 msgstr "No hay json en cache válido (no hay arreglo en /)"
 
-#: lib/replay.c:154 lib/cmdline.c:729
+#: lib/replay.c lib/cmdline.c
 #, c-format
 msgid "lint type '%s' not recognised"
 msgstr "el tipo de pelusa '%s' no se reconoce"
 
-#: lib/replay.c:181
+#: lib/replay.c
 #, c-format
 msgid "modification time of `%s` changed. Ignoring."
 msgstr "el tiempo de modificación de '%s' ha cambiado. Ignorando."
 
-#: lib/replay.c:486
+#: lib/replay.c
 #, c-format
 msgid "Loading json-results `%s'"
 msgstr "Cargando json-results '%s'"
 
-#: lib/replay.c:597
+#: lib/replay.c
 msgid "json-glib is needed for using --replay."
 msgstr "json-glib es necesario para usar --replay."
 
-#: lib/replay.c:598
+#: lib/replay.c
 msgid "Please recompile `rmlint` with it installed."
 msgstr "Por favor recompile 'rmlint' con ello instalado."
 
-#: lib/traverse.c:318
+#: lib/traverse.c
 #, c-format
 msgid "filesystem loop detected at %s (skipping)"
 msgstr "retroalimentación de sistema de archivos detectada en %s (descartando)"
 
-#: lib/traverse.c:323
+#: lib/traverse.c
 #, c-format
 msgid "cannot read directory %s: %s"
 msgstr "no se puede leer el directorio %s: %s"
 
-#: lib/traverse.c:336
+#: lib/traverse.c
 #, c-format
 msgid "error %d in fts_read for %s (skipping)"
 msgstr "error en %d en fts_read para %s (descartando)"
 
-#: lib/traverse.c:365
+#: lib/traverse.c
 #, c-format
 msgid "Added big file %s"
 msgstr "Archivo grande %s añadido"
 
-#: lib/traverse.c:367
+#: lib/traverse.c
 #, c-format
 msgid "cannot stat file %s (skipping)"
 msgstr "no se puede obtener informacion del archivo %s (descartando)"
 
-#: lib/traverse.c:414
+#: lib/traverse.c
 #, c-format
 msgid "Unknown fts_info flag %d for file %s"
 msgstr "Bandera fts_info %d desconocida para archivo %s"
 
-#: lib/traverse.c:434
+#: lib/traverse.c
 #, c-format
 msgid "'%s': fts_read failed on %s"
 msgstr "'%s': fts_read falló en %s"
 
-#: lib/cfg.c:99 lib/hash-utility.c:227
+#: lib/cfg.c lib/hash-utility.c
 #, c-format
 msgid "Can't open directory or file \"%s\": %s"
 msgstr "No se puede abrir el directorio o archivo \"%s\": %s"
 
-#: lib/cfg.c:106
+#: lib/cfg.c
 #, fuzzy, c-format
 msgid "Can't get real path for directory or file \"%s\": %s"
 msgstr "No se puede abrir el directorio o archivo \"%s\": %s"
 
-#: lib/session.c:142
+#: lib/session.c
 msgid "Received interrupt; stopping..."
 msgstr "Interrupción Recibida; deteniendo..."
 
-#: lib/session.c:156
+#: lib/session.c
 msgid "Received second interrupt; stopping hard."
 msgstr "Segunda Interrupción Recibida; deteniendo firmemente."
 
-#: lib/formats.c:219
+#: lib/formats.c
 #, c-format
 msgid "No such new_handler with this name: %s"
 msgstr "No hay tal new_handler con éste nombre: %s"
 
-#: lib/formats.c:249
+#: lib/formats.c
 #, c-format
 msgid "Unable to open file for writing: %s"
 msgstr "Incapaz de abrir archivo para escritura: %s"
 
-#: lib/hash-utility.c:56 lib/cmdline.c:904
+#: lib/hash-utility.c lib/cmdline.c
 #, c-format
 msgid "Unknown hash algorithm: '%s'"
 msgstr "Algoritmo de rastreo desconocido: '%s'"
 
-#: lib/hash-utility.c:139
+#: lib/hash-utility.c
 msgid "Digest type [BLAKE2B]"
 msgstr "Asimilación tipo [BLAKE2B]"
 
-#: lib/hash-utility.c:140
+#: lib/hash-utility.c
 msgid "Number of hashing threads [8]"
 msgstr "Número de hilos rastreados [8]"
 
-#: lib/hash-utility.c:142
+#: lib/hash-utility.c
 msgid "Megabytes read buffer [256 MB]"
 msgstr "Almacenamiento temporal de lectura de Megabytes [256]"
 
-#: lib/hash-utility.c:143
+#: lib/hash-utility.c
 msgid ""
 "Print hashes in order completed, not in order entered (reduces memory usage)"
 msgstr ""
 "Muestra a los rastreos en el orden completado, no en el orden ingresado "
 "(reduce el uso de memoria)"
 
-#: lib/hash-utility.c:144
+#: lib/hash-utility.c
 msgid "Space-separated list of files"
 msgstr "Enlistado de archivos separados-con-espacio"
 
-#: lib/hash-utility.c:150 lib/hash-utility.c:152
+#: lib/hash-utility.c
 msgid "Hash a list of files"
 msgstr "Rastrea una lista de archivos"
 
-#: lib/hash-utility.c:158
+#: lib/hash-utility.c
 #, c-format
 msgid ""
 "Multi-threaded file digest (hash) calculator.\n"
@@ -424,27 +424,27 @@ msgstr ""
 "  Soportado, mas no útil:\n"
 "    %s\n"
 
-#: lib/hash-utility.c:194
+#: lib/hash-utility.c
 #, fuzzy
 msgid "No valid paths given"
 msgstr "Ubicaciones proporcionadas no son válidas"
 
-#: lib/hash-utility.c:230
+#: lib/hash-utility.c
 #, c-format
 msgid "Directories are not supported: %s"
 msgstr "Los directorios no son soportados: %s"
 
-#: lib/hash-utility.c:239
+#: lib/hash-utility.c
 #, c-format
 msgid "%s: Unknown file type"
 msgstr "%s: Tipo de archivo desconocido"
 
-#: lib/cmdline.c:79
+#: lib/cmdline.c
 #, c-format
 msgid "compiled with:"
 msgstr "compilado con:"
 
-#: lib/cmdline.c:85
+#: lib/cmdline.c
 #, c-format
 msgid ""
 "rmlint was written by Christopher <sahib> Pahl and Daniel <SeeSpotRun> "
@@ -452,7 +452,7 @@ msgid ""
 msgstr ""
 "rmlint fué escrito por Christopher <sahib> Pahl y Daniel <SeeSpotRun> Thomas."
 
-#: lib/cmdline.c:88
+#: lib/cmdline.c
 #, c-format
 msgid ""
 "The code at https://github.com/sahib/rmlint is licensed under the terms of "
@@ -461,339 +461,339 @@ msgstr ""
 "El código en https://github.com/sahib/rmlint tiene licencia bajo los "
 "términos de el GPLv3."
 
-#: lib/cmdline.c:113
+#: lib/cmdline.c
 msgid "You seem to have no manpage for rmlint."
 msgstr "Parece que no tienes manpage (manual) para rmlint"
 
-#: lib/cmdline.c:114
+#: lib/cmdline.c
 msgid "Please run rmlint --help to show the regular help."
 msgstr ""
 
-#: lib/cmdline.c:116
+#: lib/cmdline.c
 msgid ""
 "Alternatively, visit https://rmlint.rtfd.org for the online documentation"
 msgstr ""
 
-#: lib/cmdline.c:237
+#: lib/cmdline.c
 #, fuzzy
 msgid "Usage: rmlint --dedupe [-r] source dest\n"
 msgstr "Uso: rmlint --dedupe fuente dest\n"
 
-#: lib/cmdline.c:251
+#: lib/cmdline.c lib/session.c
 msgid "dedupe: failed to open source file"
 msgstr "dedupe: no logró abrir el archivo fuente."
 
-#: lib/cmdline.c:257
+#: lib/cmdline.c lib/session.c
 #, fuzzy, c-format
 msgid "dedupe: error %i: failed to open dest file.%s"
 msgstr "dedupe: no logró abrir el archivo dest."
 
-#: lib/cmdline.c:259
+#: lib/cmdline.c lib/session.c
 msgid ""
 "\n"
 "\t(if target is a read-only snapshot then -r option is required)"
 msgstr ""
 
-#: lib/cmdline.c:295
+#: lib/cmdline.c
 #, c-format
 msgid "BTRFS_IOC_FILE_EXTENT_SAME returned error: (%d) %s"
 msgstr "BTRFS_IOC_FILE_EXTENT_SAME regresó un error: (%d) %s"
 
-#: lib/cmdline.c:298
+#: lib/cmdline.c
 msgid "Need to run as root user to clone to a read-only snapshot"
 msgstr ""
 
-#: lib/cmdline.c:300
+#: lib/cmdline.c
 #, c-format
 msgid "BTRFS_IOC_FILE_EXTENT_SAME returned status %d for file %s"
 msgstr "BTRFS_IOC_FILE_EXTENT_SAME regresó un estatus %d para el archivo %s"
 
-#: lib/cmdline.c:303
+#: lib/cmdline.c
 msgid "Files don't match - not cloned"
 msgstr "Los archivos no son iguales - no se clonó"
 
-#: lib/cmdline.c:309
+#: lib/cmdline.c
 msgid "rmlint was not compiled with btrfs support."
 msgstr "rmlint no fué compilado con soporte para btrfs"
 
-#: lib/cmdline.c:370
+#: lib/cmdline.c
 msgid "Input size is empty"
 msgstr "El tamaño de ingreso está vacío"
 
-#: lib/cmdline.c:378
+#: lib/cmdline.c
 msgid "This does not look like a number"
 msgstr "Estto no parece un número"
 
-#: lib/cmdline.c:381
+#: lib/cmdline.c
 msgid "Negativ sizes are no good idea"
 msgstr "Tamaños negativos no son una buena idea"
 
-#: lib/cmdline.c:397
+#: lib/cmdline.c
 msgid "Given format specifier not found"
 msgstr "Dicho especificador de formato no fué encontrado"
 
-#: lib/cmdline.c:429
+#: lib/cmdline.c
 msgid "Max is smaller than min"
 msgstr "Max es más pequeño que min"
 
-#: lib/cmdline.c:441
+#: lib/cmdline.c
 msgid "cannot parse --size: "
 msgstr "no se puede analizar --size: "
 
-#: lib/cmdline.c:497
+#: lib/cmdline.c
 #, c-format
 msgid "Adding -o %s as output failed"
 msgstr "Falló añadiendo -o %s como respuesta"
 
-#: lib/cmdline.c:509
+#: lib/cmdline.c
 #, c-format
 msgid "No format (format:key[=val]) specified in '%s'"
 msgstr "Sin formato (format:key[=val]) especificado en '%s'"
 
-#: lib/cmdline.c:519
+#: lib/cmdline.c
 #, c-format
 msgid "Missing key (format:key[=val]) in '%s'"
 msgstr "Llave perdida (format:key[=val]) en '%s'"
 
-#: lib/cmdline.c:534
+#: lib/cmdline.c
 #, c-format
 msgid "Invalid key `%s' for formatter `%s'"
 msgstr "Llave inválida '%s' para el formateador '%s'"
 
-#: lib/cmdline.c:561
+#: lib/cmdline.c
 #, c-format
 msgid "Unable to parse factor \"%s\": error begins at %s"
 msgstr "Incapaz de analizar el factor \"%s\": el error empieza en %s"
 
-#: lib/cmdline.c:571
+#: lib/cmdline.c
 #, c-format
 msgid "factor value is not in range [0-1]: %f"
 msgstr "el valor del factor no se encuentra dentro del rango [0-1]: %f"
 
-#: lib/cmdline.c:583
+#: lib/cmdline.c
 #, c-format
 msgid "Unable to parse offset \"%s\": "
 msgstr "Incapaz de analizar el offset \"%s\": "
 
-#: lib/cmdline.c:778
+#: lib/cmdline.c
 #, c-format
 msgid "Unable to parse time spec \"%s\""
 msgstr "Incapaz de analizar la especificación de tiempo \"%s\""
 
-#: lib/cmdline.c:792
+#: lib/cmdline.c
 #, c-format
 msgid "-n %lu is newer than current time (%lu)."
 msgstr "-n %lu es mas reciente que el tiempo actual (%lu)."
 
-#: lib/cmdline.c:881
+#: lib/cmdline.c
 msgid "Only up to -pp or down to -PP flags allowed"
 msgstr "Sólo banderas hasta -pp o menores a -PP está permitido"
 
-#: lib/cmdline.c:933
+#: lib/cmdline.c
 #, c-format
 msgid "Invalid size description \"%s\": "
 msgstr "Tamaño de descripción inválido \"%s\": "
 
-#: lib/cmdline.c:1125
+#: lib/cmdline.c
 msgid "Permissions string needs to be one or many of [rwx]"
 msgstr "La cadena de permisos necesita ser una o muchas de [rwx]"
 
-#: lib/cmdline.c:1138
+#: lib/cmdline.c
 #, c-format
 msgid "%s may only contain [%s], not `%c`"
 msgstr "%s puede únicamente contener [%s], no '%c'"
 
-#: lib/cmdline.c:1263
+#: lib/cmdline.c
 msgid "Specifiyng both -o and -O is not allowed"
 msgstr "Especificar -o y -O no está permitido"
 
-#: lib/cmdline.c:1283
+#: lib/cmdline.c
 msgid "Could not start graphical user interface."
 msgstr "No se pudo iniciar la interfase de usuario gráfica."
 
-#: lib/cmdline.c:1314
+#: lib/cmdline.c
 msgid "Specify max traversal depth"
 msgstr "Especificar la profundidad de recorrido máxima"
 
-#: lib/cmdline.c:1315
+#: lib/cmdline.c
 msgid "Select originals by given  criteria"
 msgstr "Seleccionar los originales de acuerdo a el criterio dado"
 
-#: lib/cmdline.c:1316
+#: lib/cmdline.c
 msgid "Sort rmlint output by given criteria"
 msgstr "Ordenar la respuesta de rmlint de acuerdo a el criterio dado"
 
-#: lib/cmdline.c:1317
+#: lib/cmdline.c
 msgid "Specify lint types"
 msgstr "Especificar los tipos de pelusa"
 
-#: lib/cmdline.c:1318
+#: lib/cmdline.c
 msgid "Specify size limits"
 msgstr "Especificar el límite de tamaño"
 
-#: lib/cmdline.c:1319
+#: lib/cmdline.c
 msgid "Choose hash algorithm"
 msgstr "Escoger el algoritmo de rastreo"
 
-#: lib/cmdline.c:1320
+#: lib/cmdline.c
 msgid "Add output (override default)"
 msgstr "Añadir respuesta (anula el preestablecido)"
 
-#: lib/cmdline.c:1321
+#: lib/cmdline.c
 msgid "Add output (add to defaults)"
 msgstr "Añadir respuesta (añade a el preestablecido)"
 
-#: lib/cmdline.c:1322
+#: lib/cmdline.c
 msgid "Newer than stamp file"
 msgstr "Más nuevo que el archivo de sello"
 
-#: lib/cmdline.c:1323
+#: lib/cmdline.c
 msgid "Newer than timestamp"
 msgstr "Más nuevo que la marca de tiempo"
 
-#: lib/cmdline.c:1324
+#: lib/cmdline.c
 msgid "Configure a formatter"
 msgstr "Configurar un formateador"
 
-#: lib/cmdline.c:1327
+#: lib/cmdline.c
 msgid "Enable progressbar"
 msgstr "Habilitar la barra de progreso"
 
-#: lib/cmdline.c:1328
+#: lib/cmdline.c
 msgid "Be more verbose (-vvv for much more)"
 msgstr "Sé más explicativo (-vvv para mucho más)"
 
-#: lib/cmdline.c:1329
+#: lib/cmdline.c
 msgid "Be less verbose (-VVV for much less)"
 msgstr "Sé menos explicativo (-VVV para mucho menos)"
 
-#: lib/cmdline.c:1330
+#: lib/cmdline.c
 msgid "Re-output a json file"
 msgstr "Dar respuesta nuevamente de un archivo json"
 
-#: lib/cmdline.c:1331
+#: lib/cmdline.c
 msgid "Test for equality of PATHS"
 msgstr ""
 
-#: lib/cmdline.c:1334
+#: lib/cmdline.c
 msgid "Be not that colorful"
 msgstr "No seas tan colorido"
 
-#: lib/cmdline.c:1335
+#: lib/cmdline.c
 msgid "Find hidden files"
 msgstr "Encuentra archivos ocultos"
 
-#: lib/cmdline.c:1336
+#: lib/cmdline.c
 msgid "Follow symlinks"
 msgstr "Sigue los enlaces simbólicos"
 
-#: lib/cmdline.c:1337
+#: lib/cmdline.c
 msgid "Ignore symlinks"
 msgstr "Ignora los enlaces simbólicos"
 
-#: lib/cmdline.c:1338
+#: lib/cmdline.c
 msgid "Use more paranoid hashing"
 msgstr "Usa un ratreo más paranóico"
 
-#: lib/cmdline.c:1339
+#: lib/cmdline.c
 msgid "Do not cross mounpoints"
 msgstr "No cruza los puntos de montaje"
 
-#: lib/cmdline.c:1340
+#: lib/cmdline.c
 msgid "Keep all tagged files"
 msgstr "Mantiene todos los archivos etiquetados"
 
-#: lib/cmdline.c:1341
+#: lib/cmdline.c
 msgid "Keep all untagged files"
 msgstr "Mantiene todos los archivos sin etiquetar"
 
-#: lib/cmdline.c:1342
+#: lib/cmdline.c
 msgid "Must have twin in tagged dir"
 msgstr "Debe tener gemelo en directorio etiquetado"
 
-#: lib/cmdline.c:1343
+#: lib/cmdline.c
 msgid "Must have twin in untagged dir"
 msgstr "Debe tener gemelo en directorio sin etiquetar"
 
-#: lib/cmdline.c:1344
+#: lib/cmdline.c
 msgid "Only find twins with same basename"
 msgstr "Sólo encuentra gemelos con el mismo nombre base"
 
-#: lib/cmdline.c:1345
+#: lib/cmdline.c
 msgid "Only find twins with same extension"
 msgstr "Sólo encuentra gemelos con la misma extensión"
 
-#: lib/cmdline.c:1346
+#: lib/cmdline.c
 msgid "Only find twins with same basename minus extension"
 msgstr "Sólo encuentra gemelos con el mismo nombre base menos la extensión"
 
-#: lib/cmdline.c:1347
+#: lib/cmdline.c
 msgid "Find duplicate directories"
 msgstr "Encuentra directorios duplicados"
 
-#: lib/cmdline.c:1348
+#: lib/cmdline.c
 #, fuzzy
 msgid "Only find directories with same file layout"
 msgstr "Sólo encuentra gemelos con el mismo nombre base"
 
-#: lib/cmdline.c:1349
+#: lib/cmdline.c
 msgid "Only use files with certain permissions"
 msgstr "Sólo usa archivos con ciertos permisos"
 
-#: lib/cmdline.c:1350
+#: lib/cmdline.c
 msgid "Ignore hardlink twins"
 msgstr "Ignora gemelos con hardlink"
 
-#: lib/cmdline.c:1351
+#: lib/cmdline.c
 msgid "Find hidden files in duplicate folders only"
 msgstr "Encuentra archivos ocultos en carpetas duplicadas únicamente"
 
-#: lib/cmdline.c:1352
+#: lib/cmdline.c
 msgid "Consider duplicates only equal when mtime differs at max. T seconds"
 msgstr ""
 
-#: lib/cmdline.c:1355
+#: lib/cmdline.c
 msgid "Show the manpage"
 msgstr "Muestra el manpage (manual)"
 
-#: lib/cmdline.c:1356
+#: lib/cmdline.c
 msgid "Show the version & features"
 msgstr "Muestra la versión y características"
 
-#: lib/cmdline.c:1358
+#: lib/cmdline.c
 msgid "If installed, start the optional gui with all following args"
 msgstr ""
 "Si se instaló, inicie la interfaz gráfica de usuario (gui) opcional con "
 "todos los siguientes argumentos"
 
-#: lib/cmdline.c:1359
+#: lib/cmdline.c
 msgid ""
 "Work like sha1sum for all supported hash algorithms (see also --hash --help)"
 msgstr ""
 "Trabaja como sha1sum para todos los algoritmos de rastreo soportados (ver "
 "también --hash --help)"
 
-#: lib/cmdline.c:1360
+#: lib/cmdline.c
 msgid "Clone extents from source to dest, if extents match"
 msgstr "Clona los alcances de la fuente al destino, si los alcances coinciden"
 
-#: lib/cmdline.c:1370
+#: lib/cmdline.c
 msgid "Report hardlinks as duplicates"
 msgstr "Reporta hardlinks como duplicados"
 
-#: lib/cmdline.c:1416
+#: lib/cmdline.c
 msgid "Cannot set current working directory"
 msgstr "No se puede ajustar el directorio de trabajo actual"
 
-#: lib/cmdline.c:1421
+#: lib/cmdline.c
 msgid "Cannot join commandline"
 msgstr "No se puede añadir la línea de comandos"
 
-#: lib/cmdline.c:1432
+#: lib/cmdline.c
 msgid "[TARGET_DIR_OR_FILES …] [//] [TAGGED_TARGET_DIR_OR_FILES …] [-]"
 msgstr "[TARGET_DIR_OR_FILES …] [//] [TAGGED_TARGET_DIR_OR_FILES …] [-]"
 
-#: lib/cmdline.c:1450
+#: lib/cmdline.c
 msgid ""
 "rmlint finds space waste and other broken things on your filesystem and "
 "offers to remove it.\n"
@@ -805,7 +805,7 @@ msgstr ""
 "Es especialmente bueno encontrando duplicados y ofrece una gran variedad de "
 "opciones para manejarlos."
 
-#: lib/cmdline.c:1456
+#: lib/cmdline.c
 msgid ""
 "Only the most important options and options that alter the defaults are "
 "shown above.\n"
@@ -822,55 +822,171 @@ msgstr ""
 "línea.\n"
 "Tutoriales complementarios pueden encontrarse en: http://rmlint.rtfd.org"
 
-#: lib/cmdline.c:1487
+#: lib/cmdline.c
 msgid ""
 "--honour-dir-layout (-j) makes no sense without --merge-directories (-D)"
 msgstr ""
 
-#: lib/cmdline.c:1512
+#: lib/cmdline.c
 msgid "can't specify both --keep-all-tagged and --keep-all-untagged"
 msgstr "no se puede especificar ambas --keep-all-tagged y --keep-all-untagged"
 
-#: lib/cmdline.c:1515
+#: lib/cmdline.c
 msgid "-q (--clamp-low) should be lower than -Q (--clamp-top)"
 msgstr "-q (--clamp-low) debe ser menor que -Q (--clamp-top)"
 
-#: lib/cmdline.c:1517
+#: lib/cmdline.c
 msgid "Not all given paths are valid. Aborting"
 msgstr ""
 
-#: lib/cmdline.c:1558
+#: lib/cmdline.c
 #, fuzzy
 msgid "No valid .json files given, aborting."
 msgstr "No hay json en cache válido (no hay arreglo en /)"
 
-#: lib/cmdline.c:1612
+#: lib/cmdline.c
 msgid "Using -D together with -c sh:clone is currently not possible. Sorry."
 msgstr ""
 
-#: lib/cmdline.c:1613
+#: lib/cmdline.c
 msgid "Either do not use -D, or attempt to run again with -Dj."
 msgstr ""
 
-#: lib/cmdline.c:1621
+#: lib/cmdline.c
 msgid "Not enough files for --equal (need at least two to compare)"
 msgstr ""
 
-#: lib/config.h:115
+#: lib/config.h
 msgid "ERROR"
 msgstr "ERROR"
 
-#: lib/config.h:120
+#: lib/config.h
 msgid "WARNING"
 msgstr "ADVERTENCIA"
 
-#: lib/config.h:125
+#: lib/config.h
 msgid "INFO"
 msgstr "INFO"
 
-#: lib/config.h:130
+#: lib/config.h
 msgid "DEBUG"
 msgstr "DEPURAR"
+
+#: lib/hash-utility.c
+msgid "bytes to hash at a time [4096]"
+msgstr ""
+
+#: lib/hash-utility.c
+#, fuzzy, c-format
+msgid ""
+"Multi-threaded file digest (hash) calculator.\n"
+"\n"
+"  Available digest types:\n"
+"  Cryptographic:\n"
+"    %s\n"
+"\n"
+"  Non-cryptographic:\n"
+"    %s\n"
+"\n"
+"  Supported, but not useful:\n"
+"    %s\n"
+msgstr ""
+"Calculadora de asimilación de archivos multi-hilo (rastreo).\n"
+"\n"
+"  Asimilación disponible tipos:\n"
+"    %s\n"
+"\n"
+"  Versiones con diferente números de bit:\n"
+"    %s\n"
+"\n"
+"  Soportado, mas no útil:\n"
+"    %s\n"
+
+#: lib/formats.c
+#, c-format
+msgid "Old result `%s` already exists."
+msgstr ""
+
+#: lib/formats.c
+#, c-format
+msgid "Moving old file to `%s`. Use --no-backup to disable this."
+msgstr ""
+
+#: lib/formats.c
+#, fuzzy
+msgid "failed to rename old result file"
+msgstr "dedupe: no logró abrir el archivo fuente."
+
+#: lib/session.c
+#, fuzzy
+msgid "Usage: rmlint --dedupe [-r] [-v|V] source dest\n"
+msgstr "Uso: rmlint --dedupe fuente dest\n"
+
+#: lib/session.c
+#, c-format
+msgid "%s returned error: (%d)"
+msgstr ""
+
+#: lib/session.c
+#, fuzzy
+msgid "Files don't match - not deduped"
+msgstr "Los archivos no son iguales - no se clonó"
+
+#: lib/session.c
+msgid "Only first %"
+msgstr ""
+
+#: lib/session.c
+#, fuzzy
+msgid "rmlint was not compiled with file cloning support."
+msgstr "rmlint no fué compilado con soporte para btrfs"
+
+#: lib/session.c
+#, fuzzy
+msgid "Usage: rmlint --is-clone [-v|V] file1 file2\n"
+msgstr "Uso: rmlint --dedupe fuente dest\n"
+
+#: lib/cmdline.c
+#, fuzzy, c-format
+msgid "Only up to -%.*s or down to -%.*s flags allowed"
+msgstr "Sólo banderas hasta -pp o menores a -PP está permitido"
+
+#: lib/cmdline.c
+msgid "Keep hardlink that are linked to any original"
+msgstr ""
+
+#: lib/cmdline.c
+msgid "Read null-separated file list from stdin"
+msgstr ""
+
+#: lib/cmdline.c
+msgid "Do not create backups of previous result files"
+msgstr ""
+
+#: lib/cmdline.c
+#, fuzzy
+msgid "Dedupe matching extents from source to dest (if filesystem supports)"
+msgstr "Clona los alcances de la fuente al destino, si los alcances coinciden"
+
+#: lib/cmdline.c
+msgid "(--dedupe option) even dedupe read-only snapshots (needs root)"
+msgstr ""
+
+#: lib/cmdline.c
+msgid "Test if two files are reflinks (share same data extents)"
+msgstr ""
+
+#: lib/cmdline.c
+msgid ""
+"-k and -M should not be specified at the same time (see also: https://github."
+"com/sahib/rmlint/issues/244)"
+msgstr ""
+
+#: lib/cmdline.c
+msgid ""
+"-K and -m should not be specified at the same time (see also: https://github."
+"com/sahib/rmlint/issues/244)"
+msgstr ""
 
 #~ msgid "caching is not supported due to missing json-glib library."
 #~ msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rmlint 2.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-03 22:16+0200\n"
+"POT-Creation-Date: 2018-09-27 22:59+0000\n"
 "PO-Revision-Date: 2014-12-02 13:37+0100\n"
 "Last-Translator: F. <contact@f.0x2501.org>\n"
 "Language-Team: none\n"
@@ -17,62 +17,62 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/rmlint.c:78
+#: src/rmlint.c
 #, c-format
 msgid "Aborting due to a fatal error. (signal received: %s)"
 msgstr "Arrêt causé par une erreur fatale. (signal reçu: %s)"
 
-#: src/rmlint.c:80
+#: src/rmlint.c
 msgid "Please file a bug report (See rmlint -h)"
 msgstr "Merci de remplir un rapport de bug (Voir rmlint -h)"
 
-#: lib/formats/pretty.c:34
+#: lib/formats/pretty.c
 msgid "Bad symlink(s)"
 msgstr "Mauvais lien(s) symbolique(s)"
 
-#: lib/formats/pretty.c:35
+#: lib/formats/pretty.c
 msgid "Empty dir(s)"
 msgstr "Répertoire(s) vide(s)"
 
-#: lib/formats/pretty.c:36
+#: lib/formats/pretty.c
 msgid "Non stripped binarie(s)"
 msgstr "Binaire(s) non stripped"
 
-#: lib/formats/pretty.c:37
+#: lib/formats/pretty.c
 msgid "Bad UID(s)"
 msgstr "Mauvais UID(s)"
 
-#: lib/formats/pretty.c:38
+#: lib/formats/pretty.c
 msgid "Bad GID(s)"
 msgstr "Mauvais GID(s)"
 
-#: lib/formats/pretty.c:39
+#: lib/formats/pretty.c
 msgid "Bad UID and GID(s)"
 msgstr "Mauvais UID et GID(s)"
 
-#: lib/formats/pretty.c:40
+#: lib/formats/pretty.c
 msgid "Empty file(s)"
 msgstr "Fichier(s) vide(s)"
 
-#: lib/formats/pretty.c:41
+#: lib/formats/pretty.c
 msgid "Duplicate(s)"
 msgstr "Doublon(s)"
 
-#: lib/formats/pretty.c:42
+#: lib/formats/pretty.c
 msgid "Duplicate Directorie(s)"
 msgstr "Répertoire(s) dupliqué(s)"
 
-#: lib/formats/summary.c:54
+#: lib/formats/summary.c
 #, fuzzy, c-format
 msgid " file(s) after investigation, nothing to search through.\n"
 msgstr "fichier(s) après analyse, plus rien à rechercher\n"
 
-#: lib/formats/summary.c:69
+#: lib/formats/summary.c
 #, c-format
 msgid "Early shutdown, probably not all lint was found.\n"
 msgstr "Arrêt prématuré, tous les doublons n'ont peut être pas été trouvés\n"
 
-#: lib/formats/summary.c:74
+#: lib/formats/summary.c
 #, c-format
 msgid ""
 "Note: Please use the saved script below for removal, not the above output."
@@ -80,324 +80,324 @@ msgstr ""
 "Note: S'il vous plaît utiliser le script enregistré ci-dessous "
 "pourl'enlèvement, pas la sortie ci-dessus."
 
-#: lib/formats/summary.c:87
+#: lib/formats/summary.c
 #, c-format
 msgid "In total %s files, whereof %s are duplicates in %s groups.\n"
 msgstr "%s fichiers au total, dont %s doublons répartis en %s groupe(s).\n"
 
-#: lib/formats/summary.c:95
+#: lib/formats/summary.c
 #, c-format
 msgid "This equals %s%s%s of duplicates which could be removed.\n"
 msgstr "Équivalent à %s%s%s de doublons qui peuvent être supprimés.\n"
 
-#: lib/formats/summary.c:102
+#: lib/formats/summary.c
 #, c-format
 msgid "other suspicious item(s) found, which may vary in size.\n"
 msgstr "autre(s) éléments, dont la taille peut varier, trouvé(s).\n"
 
-#: lib/formats/summary.c:107
+#: lib/formats/summary.c
 #, c-format
 msgid "Scanning took in total %s%s%s. Is that good enough?\n"
 msgstr ""
 
-#: lib/formats/summary.c:143
+#: lib/formats/summary.c
 #, c-format
 msgid "Wrote a %s%s%s file to: %s%s%s\n"
 msgstr "Fichier %s%s%s écrit: %s%s%s\n"
 
-#: lib/formats/stats.c:52
+#: lib/formats/stats.c
 #, c-format
 msgid "No shred stats.\n"
 msgstr ""
 
-#: lib/formats/stats.c:71
+#: lib/formats/stats.c
 #, c-format
 msgid ""
 "%sDuplicate finding stats (includes hardlinks):%s\n"
 "\n"
 msgstr ""
 
-#: lib/formats/stats.c:75
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s bytes of originals\n"
 msgstr ""
 
-#: lib/formats/stats.c:79
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s bytes of duplicates\n"
 msgstr ""
 
-#: lib/formats/stats.c:83
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s bytes of non-duplicates\n"
 msgstr ""
 
-#: lib/formats/stats.c:87
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s bytes of files data actually read\n"
 msgstr ""
 
-#: lib/formats/stats.c:90
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15d%s Files in total\n"
 msgstr ""
 
-#: lib/formats/stats.c:92
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15ld%s Duplicate files\n"
 msgstr ""
 
-#: lib/formats/stats.c:94
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15ld%s Groups in total\n"
 msgstr ""
 
-#: lib/formats/stats.c:96
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15ld%s Other lint items\n"
 msgstr ""
 
-#: lib/formats/stats.c:104
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s of time spent scanning\n"
 msgstr ""
 
-#: lib/formats/stats.c:122
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s Algorithm efficiency on total files basis\n"
 msgstr ""
 
-#: lib/formats/stats.c:124
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s Algorithm efficiency on duplicate file basis\n"
 msgstr ""
 
-#: lib/formats/progressbar.c:76
+#: lib/formats/progressbar.c
 msgid "reduces files to"
 msgstr "réduction des fichiers à"
 
-#: lib/formats/progressbar.c:134
+#: lib/formats/progressbar.c
 msgid "Traversing"
 msgstr "Parcoure"
 
-#: lib/formats/progressbar.c:135
+#: lib/formats/progressbar.c
 msgid "usable files"
 msgstr "fichiers utilisés"
 
-#: lib/formats/progressbar.c:138
+#: lib/formats/progressbar.c
 msgid "ignored files / folders"
 msgstr "fichiers / répertoires ignorés"
 
-#: lib/formats/progressbar.c:145
+#: lib/formats/progressbar.c
 msgid "Preprocessing"
 msgstr "Prétraitement"
 
-#: lib/formats/progressbar.c:145
+#: lib/formats/progressbar.c
 msgid "found"
 msgstr "trouvé"
 
-#: lib/formats/progressbar.c:146
+#: lib/formats/progressbar.c
 msgid "other lint"
 msgstr "autre double"
 
-#: lib/formats/progressbar.c:166
+#: lib/formats/progressbar.c
 msgid "Matching"
 msgstr "Fichiers correspondants"
 
-#: lib/formats/progressbar.c:167
+#: lib/formats/progressbar.c
 msgid "dupes of"
 msgstr "doubles de"
 
-#: lib/formats/progressbar.c:168
+#: lib/formats/progressbar.c
 msgid "originals"
 msgstr "originaux"
 
-#: lib/formats/progressbar.c:170
+#: lib/formats/progressbar.c
 #, fuzzy
 msgid "to scan in"
 msgstr "à examiner dans"
 
-#: lib/formats/progressbar.c:171
+#: lib/formats/progressbar.c
 msgid "files"
 msgstr "fichiers"
 
-#: lib/formats/progressbar.c:180
+#: lib/formats/progressbar.c
 msgid "Merging files into directories (stand by...)"
 msgstr "Fusion des fichiers dans les répertoires (attente...)"
 
-#: lib/formats/sh.c:546
+#: lib/formats/sh.c
 #, c-format
 msgid "%s is an invalid handler."
 msgstr "%s est un handler invalide"
 
-#: lib/hasher.c:310
+#: lib/hasher.c
 #, fuzzy, c-format
 msgid "Something went wrong reading %s; expected %li bytes, got %li; ignoring"
 msgstr "Problème lors de la lecture de %s; %d bytes attendus, %d reçus; ignoré"
 
-#: lib/utilities.c:315
+#: lib/utilities.c
 #, c-format
 msgid "cannot open file '%s' for nonstripped test: "
 msgstr "impossible d'ouvrir '%s' pour le test non-stripped: "
 
-#: lib/utilities.c:322
+#: lib/utilities.c
 msgid "ELF Library is out of date!"
 msgstr "La librairie ELF n'est plus à jour!"
 
-#: lib/utilities.c:662
+#: lib/utilities.c
 #, fuzzy, c-format
 msgid "`%s` mount detected at %s (#%u); Ignoring all files in it.\n"
 msgstr "`%s` monté sur %s (#%u); ses fichiers seront ignorés."
 
-#: lib/preprocess.c:236
+#: lib/preprocess.c
 msgid "Pattern has to start with `<`"
 msgstr "Motif doit commencer par `<` ou `>`"
 
-#: lib/preprocess.c:264
+#: lib/preprocess.c
 #, c-format
 msgid "`<` or `>` imbalance: %d"
 msgstr "`<` ou `>` déséquilibre: %d"
 
-#: lib/preprocess.c:271
+#: lib/preprocess.c
 msgid "empty pattern"
 msgstr "motif vide"
 
-#: lib/preprocess.c:313
+#: lib/preprocess.c
 msgid "no pattern given in <> after 'r' or 'x'"
 msgstr ""
 
-#: lib/preprocess.c:329
+#: lib/preprocess.c
 #, fuzzy, c-format
 msgid "Cannot add more than %lu regex patterns."
 msgstr "Vous ne pouvez pas ajouter plus de modèles %ld regex."
 
-#: lib/preprocess.c:341
+#: lib/preprocess.c
 msgid "Error while parsing sortcriteria patterns: "
 msgstr "Erreur lors de l'analyse des critères de tri des modèles: "
 
-#: lib/replay.c:107
+#: lib/replay.c
 msgid "No valid json cache (no array in /)"
 msgstr "JSON cache est ne pas valide"
 
-#: lib/replay.c:154 lib/cmdline.c:729
+#: lib/replay.c lib/cmdline.c
 #, c-format
 msgid "lint type '%s' not recognised"
 msgstr "doublon de type '%s' non reconnu"
 
-#: lib/replay.c:181
+#: lib/replay.c
 #, c-format
 msgid "modification time of `%s` changed. Ignoring."
 msgstr "la date de modification de `%s` a changé. Ignoré."
 
-#: lib/replay.c:486
+#: lib/replay.c
 #, fuzzy, c-format
 msgid "Loading json-results `%s'"
 msgstr "Chargement de JSON Cache `%s'"
 
-#: lib/replay.c:597
+#: lib/replay.c
 msgid "json-glib is needed for using --replay."
 msgstr "json-lib est nécessaire pour utiliser l'argument --replay"
 
-#: lib/replay.c:598
+#: lib/replay.c
 msgid "Please recompile `rmlint` with it installed."
 msgstr "Merci de recompiler `rmlint` une fois celui ci installé"
 
-#: lib/traverse.c:318
+#: lib/traverse.c
 #, c-format
 msgid "filesystem loop detected at %s (skipping)"
 msgstr "boucle dans le système de fichiers détectée à %s (ignoré)"
 
-#: lib/traverse.c:323
+#: lib/traverse.c
 #, c-format
 msgid "cannot read directory %s: %s"
 msgstr "impossible de lire le répertoire %s: %s"
 
-#: lib/traverse.c:336
+#: lib/traverse.c
 #, c-format
 msgid "error %d in fts_read for %s (skipping)"
 msgstr "erreur %d dans fts_read pour %s (ignoré) "
 
-#: lib/traverse.c:365
+#: lib/traverse.c
 #, c-format
 msgid "Added big file %s"
 msgstr "Fichier important %s ajouté"
 
-#: lib/traverse.c:367
+#: lib/traverse.c
 #, c-format
 msgid "cannot stat file %s (skipping)"
 msgstr "impossible de définir le fichier %s (ignoré)"
 
-#: lib/traverse.c:414
+#: lib/traverse.c
 #, c-format
 msgid "Unknown fts_info flag %d for file %s"
 msgstr "Drapeau fts_info %d inconnu pour le fichier %s"
 
-#: lib/traverse.c:434
+#: lib/traverse.c
 #, c-format
 msgid "'%s': fts_read failed on %s"
 msgstr "'%s': échec de fts_read pour %s"
 
-#: lib/cfg.c:99 lib/hash-utility.c:227
+#: lib/cfg.c lib/hash-utility.c
 #, fuzzy, c-format
 msgid "Can't open directory or file \"%s\": %s"
 msgstr "Impossible d'ouvrir le répertoire ou le fichier \"%s\": %s\n"
 
-#: lib/cfg.c:106
+#: lib/cfg.c
 #, fuzzy, c-format
 msgid "Can't get real path for directory or file \"%s\": %s"
 msgstr "Impossible d'ouvrir le répertoire ou le fichier \"%s\": %s\n"
 
-#: lib/session.c:142
+#: lib/session.c
 msgid "Received interrupt; stopping..."
 msgstr "Interruption demandée; arrêt..."
 
-#: lib/session.c:156
+#: lib/session.c
 msgid "Received second interrupt; stopping hard."
 msgstr "Seconde interruption demandée; arrêt brutal"
 
-#: lib/formats.c:219
+#: lib/formats.c
 #, c-format
 msgid "No such new_handler with this name: %s"
 msgstr "Aucun new_handler ne correspond à ce nom: %s"
 
-#: lib/formats.c:249
+#: lib/formats.c
 #, c-format
 msgid "Unable to open file for writing: %s"
 msgstr "Impossible d'ouvrir le fichier en écriture: %s"
 
-#: lib/hash-utility.c:56 lib/cmdline.c:904
+#: lib/hash-utility.c lib/cmdline.c
 #, c-format
 msgid "Unknown hash algorithm: '%s'"
 msgstr "Algorithme de fonction de hachage inconnue: '%s'"
 
-#: lib/hash-utility.c:139
+#: lib/hash-utility.c
 msgid "Digest type [BLAKE2B]"
 msgstr "Type digest [BLAKE2B]"
 
-#: lib/hash-utility.c:140
+#: lib/hash-utility.c
 msgid "Number of hashing threads [8]"
 msgstr "Nombre de tâches de hachage [8]"
 
-#: lib/hash-utility.c:142
+#: lib/hash-utility.c
 msgid "Megabytes read buffer [256 MB]"
 msgstr "Lecture du buffer en mégaoctets [256 MB]"
 
-#: lib/hash-utility.c:143
+#: lib/hash-utility.c
 msgid ""
 "Print hashes in order completed, not in order entered (reduces memory usage)"
 msgstr ""
 "Afficher les hachages par ordre d'achévement et non par ordre d'entrée "
 "(réduit l'utilisation de la mémoire)"
 
-#: lib/hash-utility.c:144
+#: lib/hash-utility.c
 msgid "Space-separated list of files"
 msgstr "Liste séparées par un espace de fichiers"
 
-#: lib/hash-utility.c:150 lib/hash-utility.c:152
+#: lib/hash-utility.c
 msgid "Hash a list of files"
 msgstr "Hash une liste de fichiers"
 
-#: lib/hash-utility.c:158
+#: lib/hash-utility.c
 #, c-format
 msgid ""
 "Multi-threaded file digest (hash) calculator.\n"
@@ -412,27 +412,27 @@ msgid ""
 "    %s\n"
 msgstr ""
 
-#: lib/hash-utility.c:194
+#: lib/hash-utility.c
 #, fuzzy
 msgid "No valid paths given"
 msgstr "Aucun chemin valide renseigné."
 
-#: lib/hash-utility.c:230
+#: lib/hash-utility.c
 #, c-format
 msgid "Directories are not supported: %s"
 msgstr "Ces répertoires ne sont pas pris en charge: %s"
 
-#: lib/hash-utility.c:239
+#: lib/hash-utility.c
 #, c-format
 msgid "%s: Unknown file type"
 msgstr "%s: Type de fichier inconnu"
 
-#: lib/cmdline.c:79
+#: lib/cmdline.c
 #, c-format
 msgid "compiled with:"
 msgstr "compilé par:"
 
-#: lib/cmdline.c:85
+#: lib/cmdline.c
 #, c-format
 msgid ""
 "rmlint was written by Christopher <sahib> Pahl and Daniel <SeeSpotRun> "
@@ -440,7 +440,7 @@ msgid ""
 msgstr ""
 "rmlint est codé par Christopher <sahib> Pahl et Daniel <SeeSpotRun> Thomas."
 
-#: lib/cmdline.c:88
+#: lib/cmdline.c
 #, c-format
 msgid ""
 "The code at https://github.com/sahib/rmlint is licensed under the terms of "
@@ -449,351 +449,351 @@ msgstr ""
 "Le code disponible via https://github.com/sahib/rmlint est publié sous les "
 "termes de la licenceGPLv3."
 
-#: lib/cmdline.c:113
+#: lib/cmdline.c
 msgid "You seem to have no manpage for rmlint."
 msgstr "Aucune page de manuel disponible pour rmlint"
 
-#: lib/cmdline.c:114
+#: lib/cmdline.c
 msgid "Please run rmlint --help to show the regular help."
 msgstr ""
 
-#: lib/cmdline.c:116
+#: lib/cmdline.c
 msgid ""
 "Alternatively, visit https://rmlint.rtfd.org for the online documentation"
 msgstr ""
 
-#: lib/cmdline.c:237
+#: lib/cmdline.c
 #, fuzzy
 msgid "Usage: rmlint --dedupe [-r] source dest\n"
 msgstr "Utilisation: rmlint --dedupe source dest\n"
 
-#: lib/cmdline.c:251
+#: lib/cmdline.c lib/session.c
 msgid "dedupe: failed to open source file"
 msgstr "dedupe: échec de l'ouverture du fichier source."
 
-#: lib/cmdline.c:257
+#: lib/cmdline.c lib/session.c
 #, fuzzy, c-format
 msgid "dedupe: error %i: failed to open dest file.%s"
 msgstr "dedupe: échec de l'ouverture du fichier de destination."
 
-#: lib/cmdline.c:259
+#: lib/cmdline.c lib/session.c
 msgid ""
 "\n"
 "\t(if target is a read-only snapshot then -r option is required)"
 msgstr ""
 
-#: lib/cmdline.c:295
+#: lib/cmdline.c
 #, c-format
 msgid "BTRFS_IOC_FILE_EXTENT_SAME returned error: (%d) %s"
 msgstr "BTRFS_IOC_FILE_EXTENT_SAME a retourné l'erreur: (%d) %s"
 
-#: lib/cmdline.c:298
+#: lib/cmdline.c
 msgid "Need to run as root user to clone to a read-only snapshot"
 msgstr ""
 
-#: lib/cmdline.c:300
+#: lib/cmdline.c
 #, c-format
 msgid "BTRFS_IOC_FILE_EXTENT_SAME returned status %d for file %s"
 msgstr "BTRFS_IOC_FILE_EXTENT_SAME a retourné le status %d pour le fichier %s"
 
-#: lib/cmdline.c:303
+#: lib/cmdline.c
 msgid "Files don't match - not cloned"
 msgstr "Les fichiers ne correspondent pas - aucun clonage"
 
-#: lib/cmdline.c:309
+#: lib/cmdline.c
 msgid "rmlint was not compiled with btrfs support."
 msgstr "rmlint n'a pas été complié avec le support btrfs"
 
-#: lib/cmdline.c:370
+#: lib/cmdline.c
 msgid "Input size is empty"
 msgstr "Taille entrée vide"
 
-#: lib/cmdline.c:378
+#: lib/cmdline.c
 msgid "This does not look like a number"
 msgstr "Cela ne semble pas correspondre à un chiffre"
 
-#: lib/cmdline.c:381
+#: lib/cmdline.c
 msgid "Negativ sizes are no good idea"
 msgstr "Une taille négative n'est pas une bonne idée"
 
-#: lib/cmdline.c:397
+#: lib/cmdline.c
 msgid "Given format specifier not found"
 msgstr "Format spécifié inconnu"
 
-#: lib/cmdline.c:429
+#: lib/cmdline.c
 msgid "Max is smaller than min"
 msgstr "Le maxi est plus petit que le mini"
 
-#: lib/cmdline.c:441
+#: lib/cmdline.c
 #, fuzzy
 msgid "cannot parse --size: "
 msgstr "impossible d'analyser --size: %s"
 
-#: lib/cmdline.c:497
+#: lib/cmdline.c
 #, fuzzy, c-format
 msgid "Adding -o %s as output failed"
 msgstr "Ajouter -o %s a fait échoué la sortie"
 
-#: lib/cmdline.c:509
+#: lib/cmdline.c
 #, fuzzy, c-format
 msgid "No format (format:key[=val]) specified in '%s'"
 msgstr "Aucun format (format:key[=val]) spécifié dans '%s'."
 
-#: lib/cmdline.c:519
+#: lib/cmdline.c
 #, fuzzy, c-format
 msgid "Missing key (format:key[=val]) in '%s'"
 msgstr "Clef (format:key[=val]) absente dans '%s'."
 
-#: lib/cmdline.c:534
+#: lib/cmdline.c
 #, c-format
 msgid "Invalid key `%s' for formatter `%s'"
 msgstr "Clef invalide `%s' pour le format `%s'"
 
-#: lib/cmdline.c:561
+#: lib/cmdline.c
 #, c-format
 msgid "Unable to parse factor \"%s\": error begins at %s"
 msgstr "Incapable d'analyser le facteur \"%s\": l'erreur débute à %s"
 
-#: lib/cmdline.c:571
+#: lib/cmdline.c
 #, c-format
 msgid "factor value is not in range [0-1]: %f"
 msgstr "La valeur du facteur n'est pas dans une plage de [0-1]: %f"
 
-#: lib/cmdline.c:583
+#: lib/cmdline.c
 #, fuzzy, c-format
 msgid "Unable to parse offset \"%s\": "
 msgstr "Incapable d'analyser l'offset  \"%s\": %s"
 
-#: lib/cmdline.c:778
+#: lib/cmdline.c
 #, c-format
 msgid "Unable to parse time spec \"%s\""
 msgstr "Incapable d'interpréter le temps spécifié \"%s\""
 
-#: lib/cmdline.c:792
+#: lib/cmdline.c
 #, c-format
 msgid "-n %lu is newer than current time (%lu)."
 msgstr "-n %lu est plus récent que le temps actuel (%lu)."
 
-#: lib/cmdline.c:881
+#: lib/cmdline.c
 #, fuzzy
 msgid "Only up to -pp or down to -PP flags allowed"
 msgstr "Seules les options de -ppp à -P sont autorisées"
 
-#: lib/cmdline.c:933
+#: lib/cmdline.c
 #, fuzzy, c-format
 msgid "Invalid size description \"%s\": "
 msgstr "Définition de taille invalide \"%s\": %s"
 
-#: lib/cmdline.c:1125
+#: lib/cmdline.c
 msgid "Permissions string needs to be one or many of [rwx]"
 msgstr "Les permissions doivent être parmi un ou plusieurs [rwx]"
 
-#: lib/cmdline.c:1138
+#: lib/cmdline.c
 #, c-format
 msgid "%s may only contain [%s], not `%c`"
 msgstr "%s ne peut contenir que [%s], `%c` pas."
 
-#: lib/cmdline.c:1263
+#: lib/cmdline.c
 #, fuzzy
 msgid "Specifiyng both -o and -O is not allowed"
 msgstr "Utiliser simultanément -o et -O n'est pas autorisé"
 
-#: lib/cmdline.c:1283
+#: lib/cmdline.c
 msgid "Could not start graphical user interface."
 msgstr "Impossible de démarer l'interface graphique."
 
-#: lib/cmdline.c:1314
+#: lib/cmdline.c
 msgid "Specify max traversal depth"
 msgstr "Spécifier la profondeur de traversée maximale"
 
-#: lib/cmdline.c:1315
+#: lib/cmdline.c
 #, fuzzy
 msgid "Select originals by given  criteria"
 msgstr "Critères initiaux"
 
-#: lib/cmdline.c:1316
+#: lib/cmdline.c
 #, fuzzy
 msgid "Sort rmlint output by given criteria"
 msgstr "Trier les groupes par certains critères"
 
-#: lib/cmdline.c:1317
+#: lib/cmdline.c
 msgid "Specify lint types"
 msgstr "Spécifier les types de doublons"
 
-#: lib/cmdline.c:1318
+#: lib/cmdline.c
 msgid "Specify size limits"
 msgstr "Spécifier les limites de taille"
 
-#: lib/cmdline.c:1319
+#: lib/cmdline.c
 #, fuzzy
 msgid "Choose hash algorithm"
 msgstr "Fonction de hachage inconnue: '%s'"
 
-#: lib/cmdline.c:1320
+#: lib/cmdline.c
 msgid "Add output (override default)"
 msgstr "Ajouter une sortie (remplace la valeur par défaut)"
 
-#: lib/cmdline.c:1321
+#: lib/cmdline.c
 msgid "Add output (add to defaults)"
 msgstr "Ajouter une sortie (ajouter aux valeurs par défaut)"
 
-#: lib/cmdline.c:1322
+#: lib/cmdline.c
 msgid "Newer than stamp file"
 msgstr "Plus récent que l'horodatage fichier"
 
-#: lib/cmdline.c:1323
+#: lib/cmdline.c
 msgid "Newer than timestamp"
 msgstr "Plus récent que l'horodatage"
 
-#: lib/cmdline.c:1324
+#: lib/cmdline.c
 msgid "Configure a formatter"
 msgstr "Configurer un format"
 
-#: lib/cmdline.c:1327
+#: lib/cmdline.c
 msgid "Enable progressbar"
 msgstr "Activer la barre de progression"
 
-#: lib/cmdline.c:1328
+#: lib/cmdline.c
 msgid "Be more verbose (-vvv for much more)"
 msgstr "Être plus verbeux (-vvv pour l'être encore plus)"
 
-#: lib/cmdline.c:1329
+#: lib/cmdline.c
 msgid "Be less verbose (-VVV for much less)"
 msgstr "Être moins verbeux (-VVV pour l'être encore moins)"
 
-#: lib/cmdline.c:1330
+#: lib/cmdline.c
 msgid "Re-output a json file"
 msgstr "Resortir un fichier json"
 
-#: lib/cmdline.c:1331
+#: lib/cmdline.c
 msgid "Test for equality of PATHS"
 msgstr ""
 
-#: lib/cmdline.c:1334
+#: lib/cmdline.c
 msgid "Be not that colorful"
 msgstr "Ne pas utiliser la couleur"
 
-#: lib/cmdline.c:1335
+#: lib/cmdline.c
 msgid "Find hidden files"
 msgstr "Trouver les fichiers cachés"
 
-#: lib/cmdline.c:1336
+#: lib/cmdline.c
 #, fuzzy
 msgid "Follow symlinks"
 msgstr "Mauvais lien(s) symbolique(s)"
 
-#: lib/cmdline.c:1337
+#: lib/cmdline.c
 #, fuzzy
 msgid "Ignore symlinks"
 msgstr "Mauvais lien(s) symbolique(s)"
 
-#: lib/cmdline.c:1338
+#: lib/cmdline.c
 msgid "Use more paranoid hashing"
 msgstr "Utiliser une fonction de hachage paranoïaque"
 
-#: lib/cmdline.c:1339
+#: lib/cmdline.c
 msgid "Do not cross mounpoints"
 msgstr "Ne pas traverser les points de montages"
 
-#: lib/cmdline.c:1340
+#: lib/cmdline.c
 msgid "Keep all tagged files"
 msgstr "Conserver tous les fichiers marqués"
 
-#: lib/cmdline.c:1341
+#: lib/cmdline.c
 msgid "Keep all untagged files"
 msgstr "Conserver tous les fichiers non marqués"
 
-#: lib/cmdline.c:1342
+#: lib/cmdline.c
 msgid "Must have twin in tagged dir"
 msgstr "Il doit y avoir un doublon dans le répertoire marqué"
 
-#: lib/cmdline.c:1343
+#: lib/cmdline.c
 msgid "Must have twin in untagged dir"
 msgstr "Il doit y avoir un doublon dans le répertoire non marqué"
 
-#: lib/cmdline.c:1344
+#: lib/cmdline.c
 msgid "Only find twins with same basename"
 msgstr "Chercher uniquement les doublons avec le même nom de fichier"
 
-#: lib/cmdline.c:1345
+#: lib/cmdline.c
 msgid "Only find twins with same extension"
 msgstr "Chercher uniquement les doublons avec la même extension"
 
-#: lib/cmdline.c:1346
+#: lib/cmdline.c
 msgid "Only find twins with same basename minus extension"
 msgstr ""
 "Chercher uniquement les doublons avec le même nom de fichier hors extension"
 
-#: lib/cmdline.c:1347
+#: lib/cmdline.c
 #, fuzzy
 msgid "Find duplicate directories"
 msgstr "Répertoire(s) dupliqué(s)"
 
-#: lib/cmdline.c:1348
+#: lib/cmdline.c
 #, fuzzy
 msgid "Only find directories with same file layout"
 msgstr "Chercher uniquement les doublons avec le même nom de fichier"
 
-#: lib/cmdline.c:1349
+#: lib/cmdline.c
 msgid "Only use files with certain permissions"
 msgstr "Ne prendre en compte que les fichiers avec certaines permissions"
 
-#: lib/cmdline.c:1350
+#: lib/cmdline.c
 #, fuzzy
 msgid "Ignore hardlink twins"
 msgstr "Mauvais lien(s) symbolique(s)"
 
-#: lib/cmdline.c:1351
+#: lib/cmdline.c
 msgid "Find hidden files in duplicate folders only"
 msgstr "Traiter uniquement les fichiers cachés des répertoires en doubles"
 
-#: lib/cmdline.c:1352
+#: lib/cmdline.c
 msgid "Consider duplicates only equal when mtime differs at max. T seconds"
 msgstr ""
 
-#: lib/cmdline.c:1355
+#: lib/cmdline.c
 msgid "Show the manpage"
 msgstr "Afficher la page de manuel"
 
-#: lib/cmdline.c:1356
+#: lib/cmdline.c
 msgid "Show the version & features"
 msgstr "Afficher la version et les fonctionnalités"
 
-#: lib/cmdline.c:1358
+#: lib/cmdline.c
 msgid "If installed, start the optional gui with all following args"
 msgstr ""
 "Si installé, démarrer l'interface graphique avec les arguments suivants"
 
-#: lib/cmdline.c:1359
+#: lib/cmdline.c
 msgid ""
 "Work like sha1sum for all supported hash algorithms (see also --hash --help)"
 msgstr ""
 "Fonctionne comme sha1sum pour tous les algorithmes de hachage (voir --hash --"
 "help)"
 
-#: lib/cmdline.c:1360
+#: lib/cmdline.c
 msgid "Clone extents from source to dest, if extents match"
 msgstr ""
 "Clonage d'extents de la source vers la destinations si les extents "
 "correspondent"
 
-#: lib/cmdline.c:1370
+#: lib/cmdline.c
 msgid "Report hardlinks as duplicates"
 msgstr "Considérer les liens en dur comme des doubles"
 
-#: lib/cmdline.c:1416
+#: lib/cmdline.c
 msgid "Cannot set current working directory"
 msgstr "Ne peut pas définir le répertoire de travail courant"
 
-#: lib/cmdline.c:1421
+#: lib/cmdline.c
 msgid "Cannot join commandline"
 msgstr "Impossible de joindre la ligne de commande"
 
-#: lib/cmdline.c:1432
+#: lib/cmdline.c
 msgid "[TARGET_DIR_OR_FILES …] [//] [TAGGED_TARGET_DIR_OR_FILES …] [-]"
 msgstr "[RÉPERTOIRE_OU_FICHIER …] [//] [ORIGINAL_RÉPERTOIRE_OU_FICHIER …] [-]"
 
-#: lib/cmdline.c:1450
+#: lib/cmdline.c
 msgid ""
 "rmlint finds space waste and other broken things on your filesystem and "
 "offers to remove it.\n"
@@ -805,7 +805,7 @@ msgstr ""
 "Il est particulièrement efficace pour dénicher les doublons et vous offre  "
 "une grande variété de possibilités pour les traiter."
 
-#: lib/cmdline.c:1456
+#: lib/cmdline.c
 msgid ""
 "Only the most important options and options that alter the defaults are "
 "shown above.\n"
@@ -823,58 +823,166 @@ msgstr ""
 "En complément des exemples et des tutoriaux sont proposés sur le site http://"
 "rmlint.rtfd.org"
 
-#: lib/cmdline.c:1487
+#: lib/cmdline.c
 msgid ""
 "--honour-dir-layout (-j) makes no sense without --merge-directories (-D)"
 msgstr ""
 
-#: lib/cmdline.c:1512
+#: lib/cmdline.c
 #, fuzzy
 msgid "can't specify both --keep-all-tagged and --keep-all-untagged"
 msgstr ""
 "impossible d'utiliser simultanément --keep-all-tagged et --keep-all-untagged"
 
-#: lib/cmdline.c:1515
+#: lib/cmdline.c
 #, fuzzy
 msgid "-q (--clamp-low) should be lower than -Q (--clamp-top)"
 msgstr "-q (--clamp-low) doit être plus petit que -Q (--clamp-top)!"
 
-#: lib/cmdline.c:1517
+#: lib/cmdline.c
 msgid "Not all given paths are valid. Aborting"
 msgstr ""
 
-#: lib/cmdline.c:1558
+#: lib/cmdline.c
 #, fuzzy
 msgid "No valid .json files given, aborting."
 msgstr "JSON cache est ne pas valide"
 
-#: lib/cmdline.c:1612
+#: lib/cmdline.c
 msgid "Using -D together with -c sh:clone is currently not possible. Sorry."
 msgstr ""
 
-#: lib/cmdline.c:1613
+#: lib/cmdline.c
 msgid "Either do not use -D, or attempt to run again with -Dj."
 msgstr ""
 
-#: lib/cmdline.c:1621
+#: lib/cmdline.c
 msgid "Not enough files for --equal (need at least two to compare)"
 msgstr ""
 
-#: lib/config.h:115
+#: lib/config.h
 msgid "ERROR"
 msgstr "ERREUR"
 
-#: lib/config.h:120
+#: lib/config.h
 msgid "WARNING"
 msgstr "AVERTISSEMENT"
 
-#: lib/config.h:125
+#: lib/config.h
 msgid "INFO"
 msgstr "INFO"
 
-#: lib/config.h:130
+#: lib/config.h
 msgid "DEBUG"
 msgstr "DEBUG"
+
+#: lib/hash-utility.c
+msgid "bytes to hash at a time [4096]"
+msgstr ""
+
+#: lib/hash-utility.c
+#, c-format
+msgid ""
+"Multi-threaded file digest (hash) calculator.\n"
+"\n"
+"  Available digest types:\n"
+"  Cryptographic:\n"
+"    %s\n"
+"\n"
+"  Non-cryptographic:\n"
+"    %s\n"
+"\n"
+"  Supported, but not useful:\n"
+"    %s\n"
+msgstr ""
+
+#: lib/formats.c
+#, c-format
+msgid "Old result `%s` already exists."
+msgstr ""
+
+#: lib/formats.c
+#, c-format
+msgid "Moving old file to `%s`. Use --no-backup to disable this."
+msgstr ""
+
+#: lib/formats.c
+#, fuzzy
+msgid "failed to rename old result file"
+msgstr "dedupe: échec de l'ouverture du fichier source."
+
+#: lib/session.c
+#, fuzzy
+msgid "Usage: rmlint --dedupe [-r] [-v|V] source dest\n"
+msgstr "Utilisation: rmlint --dedupe source dest\n"
+
+#: lib/session.c
+#, c-format
+msgid "%s returned error: (%d)"
+msgstr ""
+
+#: lib/session.c
+#, fuzzy
+msgid "Files don't match - not deduped"
+msgstr "Les fichiers ne correspondent pas - aucun clonage"
+
+#: lib/session.c
+msgid "Only first %"
+msgstr ""
+
+#: lib/session.c
+#, fuzzy
+msgid "rmlint was not compiled with file cloning support."
+msgstr "rmlint n'a pas été complié avec le support btrfs"
+
+#: lib/session.c
+#, fuzzy
+msgid "Usage: rmlint --is-clone [-v|V] file1 file2\n"
+msgstr "Utilisation: rmlint --dedupe source dest\n"
+
+#: lib/cmdline.c
+#, fuzzy, c-format
+msgid "Only up to -%.*s or down to -%.*s flags allowed"
+msgstr "Seules les options de -ppp à -P sont autorisées"
+
+#: lib/cmdline.c
+msgid "Keep hardlink that are linked to any original"
+msgstr ""
+
+#: lib/cmdline.c
+msgid "Read null-separated file list from stdin"
+msgstr ""
+
+#: lib/cmdline.c
+msgid "Do not create backups of previous result files"
+msgstr ""
+
+#: lib/cmdline.c
+#, fuzzy
+msgid "Dedupe matching extents from source to dest (if filesystem supports)"
+msgstr ""
+"Clonage d'extents de la source vers la destinations si les extents "
+"correspondent"
+
+#: lib/cmdline.c
+msgid "(--dedupe option) even dedupe read-only snapshots (needs root)"
+msgstr ""
+
+#: lib/cmdline.c
+msgid "Test if two files are reflinks (share same data extents)"
+msgstr ""
+
+#: lib/cmdline.c
+msgid ""
+"-k and -M should not be specified at the same time (see also: https://github."
+"com/sahib/rmlint/issues/244)"
+msgstr ""
+
+#: lib/cmdline.c
+msgid ""
+"-K and -m should not be specified at the same time (see also: https://github."
+"com/sahib/rmlint/issues/244)"
+msgstr ""
 
 #~ msgid "caching is not supported due to missing json-glib library."
 #~ msgstr "Cache non supporté, librairie json-glib manquante."

--- a/po/rmlint.pot
+++ b/po/rmlint.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: rmlint 2.5.0\n"
+"Project-Id-Version: rmlint 2.6.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-03 22:16+0200\n"
+"POT-Creation-Date: 2018-09-27 22:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,382 +17,382 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/rmlint.c:78
+#: src/rmlint.c
 #, c-format
 msgid "Aborting due to a fatal error. (signal received: %s)"
 msgstr ""
 
-#: src/rmlint.c:80
+#: src/rmlint.c
 msgid "Please file a bug report (See rmlint -h)"
 msgstr ""
 
-#: lib/formats/pretty.c:34
+#: lib/formats/pretty.c
 msgid "Bad symlink(s)"
 msgstr ""
 
-#: lib/formats/pretty.c:35
+#: lib/formats/pretty.c
 msgid "Empty dir(s)"
 msgstr ""
 
-#: lib/formats/pretty.c:36
+#: lib/formats/pretty.c
 msgid "Non stripped binarie(s)"
 msgstr ""
 
-#: lib/formats/pretty.c:37
+#: lib/formats/pretty.c
 msgid "Bad UID(s)"
 msgstr ""
 
-#: lib/formats/pretty.c:38
+#: lib/formats/pretty.c
 msgid "Bad GID(s)"
 msgstr ""
 
-#: lib/formats/pretty.c:39
+#: lib/formats/pretty.c
 msgid "Bad UID and GID(s)"
 msgstr ""
 
-#: lib/formats/pretty.c:40
+#: lib/formats/pretty.c
 msgid "Empty file(s)"
 msgstr ""
 
-#: lib/formats/pretty.c:41
+#: lib/formats/pretty.c
 msgid "Duplicate(s)"
 msgstr ""
 
-#: lib/formats/pretty.c:42
+#: lib/formats/pretty.c
 msgid "Duplicate Directorie(s)"
 msgstr ""
 
-#: lib/formats/summary.c:54
+#: lib/formats/summary.c
 #, c-format
 msgid " file(s) after investigation, nothing to search through.\n"
 msgstr ""
 
-#: lib/formats/summary.c:69
+#: lib/formats/summary.c
 #, c-format
 msgid "Early shutdown, probably not all lint was found.\n"
 msgstr ""
 
-#: lib/formats/summary.c:74
+#: lib/formats/summary.c
 #, c-format
 msgid ""
 "Note: Please use the saved script below for removal, not the above output."
 msgstr ""
 
-#: lib/formats/summary.c:87
+#: lib/formats/summary.c
 #, c-format
 msgid "In total %s files, whereof %s are duplicates in %s groups.\n"
 msgstr ""
 
-#: lib/formats/summary.c:95
+#: lib/formats/summary.c
 #, c-format
 msgid "This equals %s%s%s of duplicates which could be removed.\n"
 msgstr ""
 
-#: lib/formats/summary.c:102
+#: lib/formats/summary.c
 #, c-format
 msgid "other suspicious item(s) found, which may vary in size.\n"
 msgstr ""
 
-#: lib/formats/summary.c:107
+#: lib/formats/summary.c
 #, c-format
 msgid "Scanning took in total %s%s%s. Is that good enough?\n"
 msgstr ""
 
-#: lib/formats/summary.c:143
+#: lib/formats/summary.c
 #, c-format
 msgid "Wrote a %s%s%s file to: %s%s%s\n"
 msgstr ""
 
-#: lib/formats/stats.c:52
+#: lib/formats/stats.c
 #, c-format
 msgid "No shred stats.\n"
 msgstr ""
 
-#: lib/formats/stats.c:71
+#: lib/formats/stats.c
 #, c-format
 msgid ""
 "%sDuplicate finding stats (includes hardlinks):%s\n"
 "\n"
 msgstr ""
 
-#: lib/formats/stats.c:75
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s bytes of originals\n"
 msgstr ""
 
-#: lib/formats/stats.c:79
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s bytes of duplicates\n"
 msgstr ""
 
-#: lib/formats/stats.c:83
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s bytes of non-duplicates\n"
 msgstr ""
 
-#: lib/formats/stats.c:87
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s bytes of files data actually read\n"
 msgstr ""
 
-#: lib/formats/stats.c:90
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15d%s Files in total\n"
 msgstr ""
 
-#: lib/formats/stats.c:92
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15ld%s Duplicate files\n"
 msgstr ""
 
-#: lib/formats/stats.c:94
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15ld%s Groups in total\n"
 msgstr ""
 
-#: lib/formats/stats.c:96
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15ld%s Other lint items\n"
 msgstr ""
 
-#: lib/formats/stats.c:104
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s of time spent scanning\n"
 msgstr ""
 
-#: lib/formats/stats.c:122
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s Algorithm efficiency on total files basis\n"
 msgstr ""
 
-#: lib/formats/stats.c:124
+#: lib/formats/stats.c
 #, c-format
 msgid "%s%15s%s Algorithm efficiency on duplicate file basis\n"
 msgstr ""
 
-#: lib/formats/progressbar.c:76
+#: lib/formats/progressbar.c
 msgid "reduces files to"
 msgstr ""
 
-#: lib/formats/progressbar.c:134
+#: lib/formats/progressbar.c
 msgid "Traversing"
 msgstr ""
 
-#: lib/formats/progressbar.c:135
+#: lib/formats/progressbar.c
 msgid "usable files"
 msgstr ""
 
-#: lib/formats/progressbar.c:138
+#: lib/formats/progressbar.c
 msgid "ignored files / folders"
 msgstr ""
 
-#: lib/formats/progressbar.c:145
+#: lib/formats/progressbar.c
 msgid "Preprocessing"
 msgstr ""
 
-#: lib/formats/progressbar.c:145
+#: lib/formats/progressbar.c
 msgid "found"
 msgstr ""
 
-#: lib/formats/progressbar.c:146
+#: lib/formats/progressbar.c
 msgid "other lint"
 msgstr ""
 
-#: lib/formats/progressbar.c:166
+#: lib/formats/progressbar.c
 msgid "Matching"
 msgstr ""
 
-#: lib/formats/progressbar.c:167
+#: lib/formats/progressbar.c
 msgid "dupes of"
 msgstr ""
 
-#: lib/formats/progressbar.c:168
+#: lib/formats/progressbar.c
 msgid "originals"
 msgstr ""
 
-#: lib/formats/progressbar.c:170
+#: lib/formats/progressbar.c
 msgid "to scan in"
 msgstr ""
 
-#: lib/formats/progressbar.c:171
+#: lib/formats/progressbar.c
 msgid "files"
 msgstr ""
 
-#: lib/formats/progressbar.c:180
+#: lib/formats/progressbar.c
 msgid "Merging files into directories (stand by...)"
 msgstr ""
 
-#: lib/formats/sh.c:546
+#: lib/formats/sh.c
 #, c-format
 msgid "%s is an invalid handler."
 msgstr ""
 
-#: lib/hasher.c:310
+#: lib/hasher.c
 #, c-format
 msgid "Something went wrong reading %s; expected %li bytes, got %li; ignoring"
 msgstr ""
 
-#: lib/utilities.c:315
+#: lib/utilities.c
 #, c-format
 msgid "cannot open file '%s' for nonstripped test: "
 msgstr ""
 
-#: lib/utilities.c:322
+#: lib/utilities.c
 msgid "ELF Library is out of date!"
 msgstr ""
 
-#: lib/utilities.c:662
+#: lib/utilities.c
 #, c-format
 msgid "`%s` mount detected at %s (#%u); Ignoring all files in it.\n"
 msgstr ""
 
-#: lib/preprocess.c:236
+#: lib/preprocess.c
 msgid "Pattern has to start with `<`"
 msgstr ""
 
-#: lib/preprocess.c:264
+#: lib/preprocess.c
 #, c-format
 msgid "`<` or `>` imbalance: %d"
 msgstr ""
 
-#: lib/preprocess.c:271
+#: lib/preprocess.c
 msgid "empty pattern"
 msgstr ""
 
-#: lib/preprocess.c:313
+#: lib/preprocess.c
 msgid "no pattern given in <> after 'r' or 'x'"
 msgstr ""
 
-#: lib/preprocess.c:329
+#: lib/preprocess.c
 #, c-format
 msgid "Cannot add more than %lu regex patterns."
 msgstr ""
 
-#: lib/preprocess.c:341
+#: lib/preprocess.c
 msgid "Error while parsing sortcriteria patterns: "
 msgstr ""
 
-#: lib/replay.c:107
+#: lib/replay.c
 msgid "No valid json cache (no array in /)"
 msgstr ""
 
-#: lib/replay.c:154 lib/cmdline.c:729
+#: lib/replay.c lib/cmdline.c
 #, c-format
 msgid "lint type '%s' not recognised"
 msgstr ""
 
-#: lib/replay.c:181
+#: lib/replay.c
 #, c-format
 msgid "modification time of `%s` changed. Ignoring."
 msgstr ""
 
-#: lib/replay.c:486
+#: lib/replay.c
 #, c-format
 msgid "Loading json-results `%s'"
 msgstr ""
 
-#: lib/replay.c:597
+#: lib/replay.c
 msgid "json-glib is needed for using --replay."
 msgstr ""
 
-#: lib/replay.c:598
+#: lib/replay.c
 msgid "Please recompile `rmlint` with it installed."
 msgstr ""
 
-#: lib/traverse.c:318
+#: lib/traverse.c
 #, c-format
 msgid "filesystem loop detected at %s (skipping)"
 msgstr ""
 
-#: lib/traverse.c:323
+#: lib/traverse.c
 #, c-format
 msgid "cannot read directory %s: %s"
 msgstr ""
 
-#: lib/traverse.c:336
+#: lib/traverse.c
 #, c-format
 msgid "error %d in fts_read for %s (skipping)"
 msgstr ""
 
-#: lib/traverse.c:365
+#: lib/traverse.c
 #, c-format
 msgid "Added big file %s"
 msgstr ""
 
-#: lib/traverse.c:367
+#: lib/traverse.c
 #, c-format
 msgid "cannot stat file %s (skipping)"
 msgstr ""
 
-#: lib/traverse.c:414
+#: lib/traverse.c
 #, c-format
 msgid "Unknown fts_info flag %d for file %s"
 msgstr ""
 
-#: lib/traverse.c:434
+#: lib/traverse.c
 #, c-format
 msgid "'%s': fts_read failed on %s"
 msgstr ""
 
-#: lib/cfg.c:99 lib/hash-utility.c:227
+#: lib/cfg.c lib/hash-utility.c
 #, c-format
 msgid "Can't open directory or file \"%s\": %s"
 msgstr ""
 
-#: lib/cfg.c:106
+#: lib/cfg.c
 #, c-format
 msgid "Can't get real path for directory or file \"%s\": %s"
 msgstr ""
 
-#: lib/session.c:142
+#: lib/session.c
 msgid "Received interrupt; stopping..."
 msgstr ""
 
-#: lib/session.c:156
+#: lib/session.c
 msgid "Received second interrupt; stopping hard."
 msgstr ""
 
-#: lib/formats.c:219
+#: lib/formats.c
 #, c-format
 msgid "No such new_handler with this name: %s"
 msgstr ""
 
-#: lib/formats.c:249
+#: lib/formats.c
 #, c-format
 msgid "Unable to open file for writing: %s"
 msgstr ""
 
-#: lib/hash-utility.c:56 lib/cmdline.c:904
+#: lib/hash-utility.c lib/cmdline.c
 #, c-format
 msgid "Unknown hash algorithm: '%s'"
 msgstr ""
 
-#: lib/hash-utility.c:139
+#: lib/hash-utility.c
 msgid "Digest type [BLAKE2B]"
 msgstr ""
 
-#: lib/hash-utility.c:140
+#: lib/hash-utility.c
 msgid "Number of hashing threads [8]"
 msgstr ""
 
-#: lib/hash-utility.c:142
+#: lib/hash-utility.c
 msgid "Megabytes read buffer [256 MB]"
 msgstr ""
 
-#: lib/hash-utility.c:143
+#: lib/hash-utility.c
 msgid ""
 "Print hashes in order completed, not in order entered (reduces memory usage)"
 msgstr ""
 
-#: lib/hash-utility.c:144
+#: lib/hash-utility.c
 msgid "Space-separated list of files"
 msgstr ""
 
-#: lib/hash-utility.c:150 lib/hash-utility.c:152
+#: lib/hash-utility.c
 msgid "Hash a list of files"
 msgstr ""
 
-#: lib/hash-utility.c:158
+#: lib/hash-utility.c
 #, c-format
 msgid ""
 "Multi-threaded file digest (hash) calculator.\n"
@@ -407,366 +407,366 @@ msgid ""
 "    %s\n"
 msgstr ""
 
-#: lib/hash-utility.c:194
+#: lib/hash-utility.c
 msgid "No valid paths given"
 msgstr ""
 
-#: lib/hash-utility.c:230
+#: lib/hash-utility.c
 #, c-format
 msgid "Directories are not supported: %s"
 msgstr ""
 
-#: lib/hash-utility.c:239
+#: lib/hash-utility.c
 #, c-format
 msgid "%s: Unknown file type"
 msgstr ""
 
-#: lib/cmdline.c:79
+#: lib/cmdline.c
 #, c-format
 msgid "compiled with:"
 msgstr ""
 
-#: lib/cmdline.c:85
+#: lib/cmdline.c
 #, c-format
 msgid ""
 "rmlint was written by Christopher <sahib> Pahl and Daniel <SeeSpotRun> "
 "Thomas."
 msgstr ""
 
-#: lib/cmdline.c:88
+#: lib/cmdline.c
 #, c-format
 msgid ""
 "The code at https://github.com/sahib/rmlint is licensed under the terms of "
 "the GPLv3."
 msgstr ""
 
-#: lib/cmdline.c:113
+#: lib/cmdline.c
 msgid "You seem to have no manpage for rmlint."
 msgstr ""
 
-#: lib/cmdline.c:114
+#: lib/cmdline.c
 msgid "Please run rmlint --help to show the regular help."
 msgstr ""
 
-#: lib/cmdline.c:116
+#: lib/cmdline.c
 msgid ""
 "Alternatively, visit https://rmlint.rtfd.org for the online documentation"
 msgstr ""
 
-#: lib/cmdline.c:237
+#: lib/cmdline.c
 msgid "Usage: rmlint --dedupe [-r] source dest\n"
 msgstr ""
 
-#: lib/cmdline.c:251
+#: lib/cmdline.c lib/session.c
 msgid "dedupe: failed to open source file"
 msgstr ""
 
-#: lib/cmdline.c:257
+#: lib/cmdline.c lib/session.c
 #, c-format
 msgid "dedupe: error %i: failed to open dest file.%s"
 msgstr ""
 
-#: lib/cmdline.c:259
+#: lib/cmdline.c lib/session.c
 msgid ""
 "\n"
 "\t(if target is a read-only snapshot then -r option is required)"
 msgstr ""
 
-#: lib/cmdline.c:295
+#: lib/cmdline.c
 #, c-format
 msgid "BTRFS_IOC_FILE_EXTENT_SAME returned error: (%d) %s"
 msgstr ""
 
-#: lib/cmdline.c:298
+#: lib/cmdline.c
 msgid "Need to run as root user to clone to a read-only snapshot"
 msgstr ""
 
-#: lib/cmdline.c:300
+#: lib/cmdline.c
 #, c-format
 msgid "BTRFS_IOC_FILE_EXTENT_SAME returned status %d for file %s"
 msgstr ""
 
-#: lib/cmdline.c:303
+#: lib/cmdline.c
 msgid "Files don't match - not cloned"
 msgstr ""
 
-#: lib/cmdline.c:309
+#: lib/cmdline.c
 msgid "rmlint was not compiled with btrfs support."
 msgstr ""
 
-#: lib/cmdline.c:370
+#: lib/cmdline.c
 msgid "Input size is empty"
 msgstr ""
 
-#: lib/cmdline.c:378
+#: lib/cmdline.c
 msgid "This does not look like a number"
 msgstr ""
 
-#: lib/cmdline.c:381
+#: lib/cmdline.c
 msgid "Negativ sizes are no good idea"
 msgstr ""
 
-#: lib/cmdline.c:397
+#: lib/cmdline.c
 msgid "Given format specifier not found"
 msgstr ""
 
-#: lib/cmdline.c:429
+#: lib/cmdline.c
 msgid "Max is smaller than min"
 msgstr ""
 
-#: lib/cmdline.c:441
+#: lib/cmdline.c
 msgid "cannot parse --size: "
 msgstr ""
 
-#: lib/cmdline.c:497
+#: lib/cmdline.c
 #, c-format
 msgid "Adding -o %s as output failed"
 msgstr ""
 
-#: lib/cmdline.c:509
+#: lib/cmdline.c
 #, c-format
 msgid "No format (format:key[=val]) specified in '%s'"
 msgstr ""
 
-#: lib/cmdline.c:519
+#: lib/cmdline.c
 #, c-format
 msgid "Missing key (format:key[=val]) in '%s'"
 msgstr ""
 
-#: lib/cmdline.c:534
+#: lib/cmdline.c
 #, c-format
 msgid "Invalid key `%s' for formatter `%s'"
 msgstr ""
 
-#: lib/cmdline.c:561
+#: lib/cmdline.c
 #, c-format
 msgid "Unable to parse factor \"%s\": error begins at %s"
 msgstr ""
 
-#: lib/cmdline.c:571
+#: lib/cmdline.c
 #, c-format
 msgid "factor value is not in range [0-1]: %f"
 msgstr ""
 
-#: lib/cmdline.c:583
+#: lib/cmdline.c
 #, c-format
 msgid "Unable to parse offset \"%s\": "
 msgstr ""
 
-#: lib/cmdline.c:778
+#: lib/cmdline.c
 #, c-format
 msgid "Unable to parse time spec \"%s\""
 msgstr ""
 
-#: lib/cmdline.c:792
+#: lib/cmdline.c
 #, c-format
 msgid "-n %lu is newer than current time (%lu)."
 msgstr ""
 
-#: lib/cmdline.c:881
+#: lib/cmdline.c
 msgid "Only up to -pp or down to -PP flags allowed"
 msgstr ""
 
-#: lib/cmdline.c:933
+#: lib/cmdline.c
 #, c-format
 msgid "Invalid size description \"%s\": "
 msgstr ""
 
-#: lib/cmdline.c:1125
+#: lib/cmdline.c
 msgid "Permissions string needs to be one or many of [rwx]"
 msgstr ""
 
-#: lib/cmdline.c:1138
+#: lib/cmdline.c
 #, c-format
 msgid "%s may only contain [%s], not `%c`"
 msgstr ""
 
-#: lib/cmdline.c:1263
+#: lib/cmdline.c
 msgid "Specifiyng both -o and -O is not allowed"
 msgstr ""
 
-#: lib/cmdline.c:1283
+#: lib/cmdline.c
 msgid "Could not start graphical user interface."
 msgstr ""
 
-#: lib/cmdline.c:1314
+#: lib/cmdline.c
 msgid "Specify max traversal depth"
 msgstr ""
 
-#: lib/cmdline.c:1315
+#: lib/cmdline.c
 msgid "Select originals by given  criteria"
 msgstr ""
 
-#: lib/cmdline.c:1316
+#: lib/cmdline.c
 msgid "Sort rmlint output by given criteria"
 msgstr ""
 
-#: lib/cmdline.c:1317
+#: lib/cmdline.c
 msgid "Specify lint types"
 msgstr ""
 
-#: lib/cmdline.c:1318
+#: lib/cmdline.c
 msgid "Specify size limits"
 msgstr ""
 
-#: lib/cmdline.c:1319
+#: lib/cmdline.c
 msgid "Choose hash algorithm"
 msgstr ""
 
-#: lib/cmdline.c:1320
+#: lib/cmdline.c
 msgid "Add output (override default)"
 msgstr ""
 
-#: lib/cmdline.c:1321
+#: lib/cmdline.c
 msgid "Add output (add to defaults)"
 msgstr ""
 
-#: lib/cmdline.c:1322
+#: lib/cmdline.c
 msgid "Newer than stamp file"
 msgstr ""
 
-#: lib/cmdline.c:1323
+#: lib/cmdline.c
 msgid "Newer than timestamp"
 msgstr ""
 
-#: lib/cmdline.c:1324
+#: lib/cmdline.c
 msgid "Configure a formatter"
 msgstr ""
 
-#: lib/cmdline.c:1327
+#: lib/cmdline.c
 msgid "Enable progressbar"
 msgstr ""
 
-#: lib/cmdline.c:1328
+#: lib/cmdline.c
 msgid "Be more verbose (-vvv for much more)"
 msgstr ""
 
-#: lib/cmdline.c:1329
+#: lib/cmdline.c
 msgid "Be less verbose (-VVV for much less)"
 msgstr ""
 
-#: lib/cmdline.c:1330
+#: lib/cmdline.c
 msgid "Re-output a json file"
 msgstr ""
 
-#: lib/cmdline.c:1331
+#: lib/cmdline.c
 msgid "Test for equality of PATHS"
 msgstr ""
 
-#: lib/cmdline.c:1334
+#: lib/cmdline.c
 msgid "Be not that colorful"
 msgstr ""
 
-#: lib/cmdline.c:1335
+#: lib/cmdline.c
 msgid "Find hidden files"
 msgstr ""
 
-#: lib/cmdline.c:1336
+#: lib/cmdline.c
 msgid "Follow symlinks"
 msgstr ""
 
-#: lib/cmdline.c:1337
+#: lib/cmdline.c
 msgid "Ignore symlinks"
 msgstr ""
 
-#: lib/cmdline.c:1338
+#: lib/cmdline.c
 msgid "Use more paranoid hashing"
 msgstr ""
 
-#: lib/cmdline.c:1339
+#: lib/cmdline.c
 msgid "Do not cross mounpoints"
 msgstr ""
 
-#: lib/cmdline.c:1340
+#: lib/cmdline.c
 msgid "Keep all tagged files"
 msgstr ""
 
-#: lib/cmdline.c:1341
+#: lib/cmdline.c
 msgid "Keep all untagged files"
 msgstr ""
 
-#: lib/cmdline.c:1342
+#: lib/cmdline.c
 msgid "Must have twin in tagged dir"
 msgstr ""
 
-#: lib/cmdline.c:1343
+#: lib/cmdline.c
 msgid "Must have twin in untagged dir"
 msgstr ""
 
-#: lib/cmdline.c:1344
+#: lib/cmdline.c
 msgid "Only find twins with same basename"
 msgstr ""
 
-#: lib/cmdline.c:1345
+#: lib/cmdline.c
 msgid "Only find twins with same extension"
 msgstr ""
 
-#: lib/cmdline.c:1346
+#: lib/cmdline.c
 msgid "Only find twins with same basename minus extension"
 msgstr ""
 
-#: lib/cmdline.c:1347
+#: lib/cmdline.c
 msgid "Find duplicate directories"
 msgstr ""
 
-#: lib/cmdline.c:1348
+#: lib/cmdline.c
 msgid "Only find directories with same file layout"
 msgstr ""
 
-#: lib/cmdline.c:1349
+#: lib/cmdline.c
 msgid "Only use files with certain permissions"
 msgstr ""
 
-#: lib/cmdline.c:1350
+#: lib/cmdline.c
 msgid "Ignore hardlink twins"
 msgstr ""
 
-#: lib/cmdline.c:1351
+#: lib/cmdline.c
 msgid "Find hidden files in duplicate folders only"
 msgstr ""
 
-#: lib/cmdline.c:1352
+#: lib/cmdline.c
 msgid "Consider duplicates only equal when mtime differs at max. T seconds"
 msgstr ""
 
-#: lib/cmdline.c:1355
+#: lib/cmdline.c
 msgid "Show the manpage"
 msgstr ""
 
-#: lib/cmdline.c:1356
+#: lib/cmdline.c
 msgid "Show the version & features"
 msgstr ""
 
-#: lib/cmdline.c:1358
+#: lib/cmdline.c
 msgid "If installed, start the optional gui with all following args"
 msgstr ""
 
-#: lib/cmdline.c:1359
+#: lib/cmdline.c
 msgid ""
 "Work like sha1sum for all supported hash algorithms (see also --hash --help)"
 msgstr ""
 
-#: lib/cmdline.c:1360
+#: lib/cmdline.c
 msgid "Clone extents from source to dest, if extents match"
 msgstr ""
 
-#: lib/cmdline.c:1370
+#: lib/cmdline.c
 msgid "Report hardlinks as duplicates"
 msgstr ""
 
-#: lib/cmdline.c:1416
+#: lib/cmdline.c
 msgid "Cannot set current working directory"
 msgstr ""
 
-#: lib/cmdline.c:1421
+#: lib/cmdline.c
 msgid "Cannot join commandline"
 msgstr ""
 
-#: lib/cmdline.c:1432
+#: lib/cmdline.c
 msgid "[TARGET_DIR_OR_FILES …] [//] [TAGGED_TARGET_DIR_OR_FILES …] [-]"
 msgstr ""
 
-#: lib/cmdline.c:1450
+#: lib/cmdline.c
 msgid ""
 "rmlint finds space waste and other broken things on your filesystem and "
 "offers to remove it.\n"
@@ -774,7 +774,7 @@ msgid ""
 "options to handle them."
 msgstr ""
 
-#: lib/cmdline.c:1456
+#: lib/cmdline.c
 msgid ""
 "Only the most important options and options that alter the defaults are "
 "shown above.\n"
@@ -784,51 +784,151 @@ msgid ""
 "Complementary tutorials can be found at: http://rmlint.rtfd.org"
 msgstr ""
 
-#: lib/cmdline.c:1487
+#: lib/cmdline.c
 msgid ""
 "--honour-dir-layout (-j) makes no sense without --merge-directories (-D)"
 msgstr ""
 
-#: lib/cmdline.c:1512
+#: lib/cmdline.c
 msgid "can't specify both --keep-all-tagged and --keep-all-untagged"
 msgstr ""
 
-#: lib/cmdline.c:1515
+#: lib/cmdline.c
 msgid "-q (--clamp-low) should be lower than -Q (--clamp-top)"
 msgstr ""
 
-#: lib/cmdline.c:1517
+#: lib/cmdline.c
 msgid "Not all given paths are valid. Aborting"
 msgstr ""
 
-#: lib/cmdline.c:1558
+#: lib/cmdline.c
 msgid "No valid .json files given, aborting."
 msgstr ""
 
-#: lib/cmdline.c:1612
+#: lib/cmdline.c
 msgid "Using -D together with -c sh:clone is currently not possible. Sorry."
 msgstr ""
 
-#: lib/cmdline.c:1613
+#: lib/cmdline.c
 msgid "Either do not use -D, or attempt to run again with -Dj."
 msgstr ""
 
-#: lib/cmdline.c:1621
+#: lib/cmdline.c
 msgid "Not enough files for --equal (need at least two to compare)"
 msgstr ""
 
-#: lib/config.h:115
+#: lib/config.h
 msgid "ERROR"
 msgstr ""
 
-#: lib/config.h:120
+#: lib/config.h
 msgid "WARNING"
 msgstr ""
 
-#: lib/config.h:125
+#: lib/config.h
 msgid "INFO"
 msgstr ""
 
-#: lib/config.h:130
+#: lib/config.h
 msgid "DEBUG"
+msgstr ""
+
+#: lib/hash-utility.c
+msgid "bytes to hash at a time [4096]"
+msgstr ""
+
+#: lib/hash-utility.c
+#, c-format
+msgid ""
+"Multi-threaded file digest (hash) calculator.\n"
+"\n"
+"  Available digest types:\n"
+"  Cryptographic:\n"
+"    %s\n"
+"\n"
+"  Non-cryptographic:\n"
+"    %s\n"
+"\n"
+"  Supported, but not useful:\n"
+"    %s\n"
+msgstr ""
+
+#: lib/formats.c
+#, c-format
+msgid "Old result `%s` already exists."
+msgstr ""
+
+#: lib/formats.c
+#, c-format
+msgid "Moving old file to `%s`. Use --no-backup to disable this."
+msgstr ""
+
+#: lib/formats.c
+msgid "failed to rename old result file"
+msgstr ""
+
+#: lib/session.c
+msgid "Usage: rmlint --dedupe [-r] [-v|V] source dest\n"
+msgstr ""
+
+#: lib/session.c
+#, c-format
+msgid "%s returned error: (%d)"
+msgstr ""
+
+#: lib/session.c
+msgid "Files don't match - not deduped"
+msgstr ""
+
+#: lib/session.c
+msgid "Only first %"
+msgstr ""
+
+#: lib/session.c
+msgid "rmlint was not compiled with file cloning support."
+msgstr ""
+
+#: lib/session.c
+msgid "Usage: rmlint --is-clone [-v|V] file1 file2\n"
+msgstr ""
+
+#: lib/cmdline.c
+#, c-format
+msgid "Only up to -%.*s or down to -%.*s flags allowed"
+msgstr ""
+
+#: lib/cmdline.c
+msgid "Keep hardlink that are linked to any original"
+msgstr ""
+
+#: lib/cmdline.c
+msgid "Read null-separated file list from stdin"
+msgstr ""
+
+#: lib/cmdline.c
+msgid "Do not create backups of previous result files"
+msgstr ""
+
+#: lib/cmdline.c
+msgid "Dedupe matching extents from source to dest (if filesystem supports)"
+msgstr ""
+
+#: lib/cmdline.c
+msgid "(--dedupe option) even dedupe read-only snapshots (needs root)"
+msgstr ""
+
+#: lib/cmdline.c
+msgid "Test if two files are reflinks (share same data extents)"
+msgstr ""
+
+#: lib/cmdline.c
+msgid ""
+"-k and -M should not be specified at the same time (see also: https://github."
+"com/sahib/rmlint/issues/244)"
+msgstr ""
+
+#: lib/cmdline.c
+msgid ""
+"-K and -m should not be specified at the same time (see also: https://github."
+"com/sahib/rmlint/issues/244)"
 msgstr ""


### PR DESCRIPTION
This series implements the means by which `gettext` translation files can be updated with one command:

    $ scons gettext

It also uses this new facility to update the `po/*.po[t]` files (however, no new translations are provided).