### PR TITLE
Cleanup in treemerge (and others)

### DIFF
--- a/lib/cmdline.c
+++ b/lib/cmdline.c
@@ -1627,7 +1627,11 @@ int rm_cmd_main(RmSession *session) {
             return EXIT_FAILURE;
         }
 
-        session->dir_merger = rm_tm_new(session);
+        RmTreeMerger *t = session->dir_merger = rm_tm_new(session);
+        if(!t) {
+            rm_log_error_line(_("Failed to complete setup for merging directories"));
+            return EXIT_FAILURE;
+        }
     }
 
     if(session->total_files < 2 && session->cfg->run_equal_mode) {

--- a/lib/cmdline.c
+++ b/lib/cmdline.c
@@ -1586,7 +1586,7 @@ int rm_cmd_main(RmSession *session) {
 
     rm_fmt_set_state(session->formats, RM_PROGRESS_STATE_INIT);
 
-    if(session->cfg->replay) {
+    if(cfg->replay) {
         return rm_cmd_replay_main(session);
     }
 

--- a/lib/fts/fts.c
+++ b/lib/fts/fts.c
@@ -62,7 +62,8 @@ static FTSENT *fts_build(FTS *, int);
 static void fts_free(FTSENT *);
 static void fts_lfree(FTSENT *);
 static void fts_load(FTS *, FTSENT *);
-static size_t fts_maxarglen(char *const *);
+typedef const char *Path;
+static size_t fts_maxarglen(const Path *);
 static size_t fts_pow2(size_t);
 static int fts_palloc(FTS *, size_t);
 static void fts_padjust(FTS *, FTSENT *);
@@ -107,7 +108,7 @@ static int fts_safe_changedir(const FTS *, const FTSENT *, int, const char *);
 #undef FTS_WHITEOUT
 #endif
 
-FTS *fts_open(char *const *argv, int options,
+FTS *fts_open(const Path *argv, int options,
               int (*compar)(const FTSENT **, const FTSENT **)) {
     FTS *sp;
     FTSENT *p, *root;
@@ -1152,7 +1153,7 @@ static void fts_padjust(FTS *sp, FTSENT *head) {
     }
 }
 
-static size_t fts_maxarglen(char *const *argv) {
+static size_t fts_maxarglen(const Path *argv) {
     size_t len, max;
 
     _DIAGASSERT(argv != NULL);

--- a/lib/fts/fts.h
+++ b/lib/fts/fts.h
@@ -143,7 +143,8 @@ extern "C" {
 #endif
 FTSENT *fts_children(FTS *, int);
 int fts_close(FTS *);
-FTS *fts_open(char *const *, int, int (*)(const FTSENT **, const FTSENT **));
+typedef const char *Path;
+FTS *fts_open(const Path *, int, int (*)(const FTSENT **, const FTSENT **));
 FTSENT *fts_read(FTS *);
 int fts_set(FTS *, FTSENT *, int);
 #ifdef __cplusplus

--- a/lib/traverse.c
+++ b/lib/traverse.c
@@ -473,7 +473,7 @@ void rm_traverse_tree(RmSession *session) {
                      (RmMDSFunc)rm_traverse_directory,
                      trav_session,
                      0,
-                     session->cfg->threads_per_disk,
+                     cfg->threads_per_disk,
                      NULL);
 
     /* iterate through paths */

--- a/lib/traverse.c
+++ b/lib/traverse.c
@@ -264,7 +264,8 @@ static void rm_traverse_directory(RmTravBuffer *buffer, RmTravSession *trav_sess
         rm_log_debug_line("Treating files under %s as a single volume", rmpath->path);
     }
 
-    FTS *ftsp = fts_open((char *[2]){rmpath->path, NULL}, fts_flags, NULL);
+    typedef const char *Path;
+    FTS *ftsp = fts_open((const Path[2]){rmpath->path, NULL}, fts_flags, NULL);
 
     if(ftsp == NULL) {
         rm_log_error_line("fts_open() == NULL");

--- a/lib/treemerge.c
+++ b/lib/treemerge.c
@@ -178,12 +178,13 @@ int rm_tm_count_art_callback(_UNUSED RmTrie *self, RmNode *node, _UNUSED int lev
     return 0;
 }
 
-static bool rm_tm_count_files(RmTrie *count_tree, GSList *paths, const RmCfg *const cfg) {
+static bool rm_tm_count_files(RmTrie *count_tree, const RmCfg *const cfg) {
     /* put paths into format expected by fts */
 
     g_assert(cfg);
+    guint path_count = cfg->path_count;
+    const GSList *paths = cfg->paths;
 
-    guint path_count = g_slist_length(paths);
     char **path_vec = g_malloc0(sizeof(char *) * (path_count + 1));
     for(guint idx = 0; paths && idx < path_count; idx++, paths = paths->next) {
         path_vec[idx] = ((RmPath *)paths->data)->path;
@@ -260,7 +261,7 @@ static bool rm_tm_count_files(RmTrie *count_tree, GSList *paths, const RmCfg *co
 
     /* Now flag everything as a no-go over the given paths,
      * otherwise we would continue merging till / with fatal consequences,
-     * since / does not have more files as paths[0]
+     * since / does not have more files than path_vec[0]
      */
     for(int i = 0; path_vec[i]; ++i) {
         /* Just call the callback directly */
@@ -521,7 +522,7 @@ RmTreeMerger *rm_tm_new(RmSession *session) {
     rm_trie_init(&self->dir_tree);
     rm_trie_init(&self->count_tree);
 
-    rm_tm_count_files(&self->count_tree, session->cfg->paths, session->cfg);
+    rm_tm_count_files(&self->count_tree, session->cfg);
 
     return self;
 }

--- a/lib/treemerge.c
+++ b/lib/treemerge.c
@@ -178,8 +178,11 @@ int rm_tm_count_art_callback(_UNUSED RmTrie *self, RmNode *node, _UNUSED int lev
     return 0;
 }
 
-static bool rm_tm_count_files(RmTrie *count_tree, GSList *paths, RmSession *session) {
+static bool rm_tm_count_files(RmTrie *count_tree, GSList *paths, const RmCfg *const cfg) {
     /* put paths into format expected by fts */
+
+    g_assert(cfg);
+
     guint path_count = g_slist_length(paths);
     char **path_vec = g_malloc0(sizeof(char *) * (path_count + 1));
     for(guint idx = 0; paths && idx < path_count; idx++, paths = paths->next) {
@@ -231,8 +234,8 @@ static bool rm_tm_count_files(RmTrie *count_tree, GSList *paths, RmSession *sess
         case FTS_SLNONE:
         case FTS_DEFAULT:
             /* Save this path as countable file, but only if we consider empty files */
-            if(!(session->cfg->find_emptyfiles) || ent->fts_statp->st_size > 0) {
-                if(!(session->cfg->follow_symlinks && ent->fts_info == FTS_SL)) {
+            if(!(cfg->find_emptyfiles) || ent->fts_statp->st_size > 0) {
+                if(!(cfg->follow_symlinks && ent->fts_info == FTS_SL)) {
                     rm_trie_insert(&file_tree, ent->fts_path, GINT_TO_POINTER(false));
                 }
             }
@@ -518,7 +521,7 @@ RmTreeMerger *rm_tm_new(RmSession *session) {
     rm_trie_init(&self->dir_tree);
     rm_trie_init(&self->count_tree);
 
-    rm_tm_count_files(&self->count_tree, session->cfg->paths, session);
+    rm_tm_count_files(&self->count_tree, session->cfg->paths, session->cfg);
 
     return self;
 }

--- a/lib/treemerge.c
+++ b/lib/treemerge.c
@@ -185,7 +185,8 @@ static bool rm_tm_count_files(RmTrie *count_tree, const RmCfg *const cfg) {
     guint path_count = cfg->path_count;
     const GSList *paths = cfg->paths;
 
-    char **path_vec = g_malloc0(sizeof(char *) * (path_count + 1));
+    typedef const char *Path;
+    Path *const path_vec = g_malloc0(sizeof(Path) * (path_count + 1));
     for(guint idx = 0; paths && idx < path_count; idx++, paths = paths->next) {
         path_vec[idx] = ((RmPath *)paths->data)->path;
     }

--- a/lib/treemerge.c
+++ b/lib/treemerge.c
@@ -193,13 +193,13 @@ static bool rm_tm_count_files(RmTrie *count_tree, const RmCfg *const cfg) {
         return false;
     }
 
-    Path *path = path_vec;
+    Path *path = path_vec + path_count;
+    *path = 0;
     for(const GSList *paths = cfg->paths; path_count--; paths = paths->next) {
         g_assert(paths);
         g_assert(paths->data);
-        *(path++) = ((RmPath *)paths->data)->path;
+        *(--path) = ((RmPath *)paths->data)->path;
     }
-    *path = 0;
 
     /* This tree stores the full file paths.
        It is joined into a full directory tree later.
@@ -268,7 +268,7 @@ static bool rm_tm_count_files(RmTrie *count_tree, const RmCfg *const cfg) {
      * otherwise we would continue merging till / with fatal consequences,
      * since / does not have more files than path_vec[0]
      */
-    for(path = path_vec; *path; ++path) {
+    for(/*path = path_vec*/; *path; ++path) {
         /* Just call the callback directly */
         RmNode *node = rm_trie_search_node(&file_tree, *path);
         if(node != NULL) {

--- a/lib/treemerge.c
+++ b/lib/treemerge.c
@@ -183,12 +183,15 @@ static bool rm_tm_count_files(RmTrie *count_tree, const RmCfg *const cfg) {
 
     g_assert(cfg);
     guint path_count = cfg->path_count;
-    const GSList *paths = cfg->paths;
 
     typedef const char *Path;
     Path *const path_vec = g_malloc0(sizeof(Path) * (path_count + 1));
-    for(guint idx = 0; paths && idx < path_count; idx++, paths = paths->next) {
-        path_vec[idx] = ((RmPath *)paths->data)->path;
+
+    Path *path = path_vec;
+    for(const GSList *paths = cfg->paths; path_count--; paths = paths->next) {
+        g_assert(paths);
+        g_assert(paths->data);
+        *(path++) = ((RmPath *)paths->data)->path;
     }
 
     if(*path_vec == NULL) {
@@ -264,9 +267,9 @@ static bool rm_tm_count_files(RmTrie *count_tree, const RmCfg *const cfg) {
      * otherwise we would continue merging till / with fatal consequences,
      * since / does not have more files than path_vec[0]
      */
-    for(int i = 0; path_vec[i]; ++i) {
+    for(path = path_vec; *path; ++path) {
         /* Just call the callback directly */
-        RmNode *node = rm_trie_search_node(&file_tree, path_vec[i]);
+        RmNode *node = rm_trie_search_node(&file_tree, *path);
         if(node != NULL) {
             node->data = GINT_TO_POINTER(true);
             rm_tm_count_art_callback(&file_tree, node, 0, count_tree);

--- a/lib/treemerge.c
+++ b/lib/treemerge.c
@@ -183,9 +183,15 @@ static bool rm_tm_count_files(RmTrie *count_tree, const RmCfg *const cfg) {
 
     g_assert(cfg);
     guint path_count = cfg->path_count;
+    g_assert(path_count);
 
     typedef const char *Path;
-    Path *const path_vec = g_malloc0(sizeof(Path) * (path_count + 1));
+    Path *const path_vec = malloc(sizeof(Path) * (path_count + 1));
+
+    if(!path_vec) {
+        rm_log_error(_("Failed to allocate memory. Out of memory?"));
+        return false;
+    }
 
     Path *path = path_vec;
     for(const GSList *paths = cfg->paths; path_count--; paths = paths->next) {
@@ -193,12 +199,7 @@ static bool rm_tm_count_files(RmTrie *count_tree, const RmCfg *const cfg) {
         g_assert(paths->data);
         *(path++) = ((RmPath *)paths->data)->path;
     }
-
-    if(*path_vec == NULL) {
-        rm_log_error("No paths passed to rm_tm_count_files\n");
-        g_free(path_vec);
-        return false;
-    }
+    *path = 0;
 
     /* This tree stores the full file paths.
        It is joined into a full directory tree later.
@@ -526,7 +527,9 @@ RmTreeMerger *rm_tm_new(RmSession *session) {
     rm_trie_init(&self->dir_tree);
     rm_trie_init(&self->count_tree);
 
-    rm_tm_count_files(&self->count_tree, session->cfg);
+    if(!rm_tm_count_files(&self->count_tree, session->cfg)) {
+        return 0;
+    }
 
     return self;
 }

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rmlint 2.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-27 22:59+0000\n"
+"POT-Creation-Date: 2018-09-27 23:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1009,6 +1009,14 @@ msgstr ""
 msgid ""
 "-K and -m should not be specified at the same time (see also: https://github."
 "com/sahib/rmlint/issues/244)"
+msgstr ""
+
+#: lib/cmdline.c
+msgid "Failed to complete setup for merging directories"
+msgstr ""
+
+#: lib/treemerge.c
+msgid "Failed to allocate memory. Out of memory?"
 msgstr ""
 
 #~ msgid "%s%15"

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rmlint 2.4.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-27 22:59+0000\n"
+"POT-Creation-Date: 2018-09-27 23:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -986,6 +986,14 @@ msgstr ""
 msgid ""
 "-K and -m should not be specified at the same time (see also: https://github."
 "com/sahib/rmlint/issues/244)"
+msgstr ""
+
+#: lib/cmdline.c
+msgid "Failed to complete setup for merging directories"
+msgstr ""
+
+#: lib/treemerge.c
+msgid "Failed to allocate memory. Out of memory?"
 msgstr ""
 
 #~ msgid "caching is not supported due to missing json-glib library."

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rmlint 2.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-27 22:59+0000\n"
+"POT-Creation-Date: 2018-09-27 23:04+0000\n"
 "PO-Revision-Date: 2014-12-02 13:37+0100\n"
 "Last-Translator: F. <contact@f.0x2501.org>\n"
 "Language-Team: none\n"
@@ -982,6 +982,14 @@ msgstr ""
 msgid ""
 "-K and -m should not be specified at the same time (see also: https://github."
 "com/sahib/rmlint/issues/244)"
+msgstr ""
+
+#: lib/cmdline.c
+msgid "Failed to complete setup for merging directories"
+msgstr ""
+
+#: lib/treemerge.c
+msgid "Failed to allocate memory. Out of memory?"
 msgstr ""
 
 #~ msgid "caching is not supported due to missing json-glib library."

--- a/po/rmlint.pot
+++ b/po/rmlint.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rmlint 2.6.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-27 22:59+0000\n"
+"POT-Creation-Date: 2018-09-27 23:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -931,4 +931,12 @@ msgstr ""
 msgid ""
 "-K and -m should not be specified at the same time (see also: https://github."
 "com/sahib/rmlint/issues/244)"
+msgstr ""
+
+#: lib/cmdline.c
+msgid "Failed to complete setup for merging directories"
+msgstr ""
+
+#: lib/treemerge.c
+msgid "Failed to allocate memory. Out of memory?"
 msgstr ""


### PR DESCRIPTION
This series mainly improves `rm_tm_count_files()` by removing an unnecessary parameter, avoiding re-calculation, and introducing [slightly more] graceful error handling. It may be helpful to consult the commit mesage in the following commit of the series:

* lib/treemerge.c: remove unnecessary parameter and recalculation of `path_count' (a5ef34b881d95e41b08ae5a91c92cb0d8cb47517)