### PR TITLE
Forbid `--replay' with `--dedupe' or `--is-reflink'

### DIFF
--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -107,9 +107,25 @@ typedef struct RmCfg {
     RmOff skip_start_offset;
     RmOff skip_end_offset;
 
-    /* paths passed by command line */
+    /* paths passed by command line (or stdin) */
     GSList *paths;
     GSList *json_paths;
+
+    /* This variable is used for 2 purposes:
+     *
+     *   + To record  a  unique  index for each path supplied by the
+     *     user; a path's index represents  the number of paths that
+     *     were already processed. This is always the case.
+     *
+     *   + To provide  quick  access to the length of its associated
+     *     RmCfg::paths list. This is only the case when NOT running
+     *     in "--replay"  mode; when running in  "--replay" mode, it
+     *     just represents the total number  of paths that have been
+     *     supplied by  the user, i.e.,  the sums of the  lengths of
+     *     the associated lists  RmCfg::{paths,json_paths}, which is
+     *     not meant to be a useful  number to know, and is simply a
+     *     byproduct of calculating path indicies.
+     */
     guint path_count;
 
     /* working dir rmlint called from */

--- a/lib/cmdline.c
+++ b/lib/cmdline.c
@@ -1468,6 +1468,13 @@ bool rm_cmd_parse_args(int argc, char **argv, RmSession *session) {
         goto cleanup;
     }
 
+    if(cfg->replay && (cfg->dedupe || cfg->is_reflink)) {
+        error = g_error_new(
+            RM_ERROR_QUARK, 0,
+            _("--replay (-Y) is incompatible with --dedupe or --is-reflink")
+        ); goto cleanup;
+    }
+
     if(cfg->dedupe) {
         /* dedupe session; regular rmlint configs are ignored */
         goto cleanup;

--- a/lib/session.c
+++ b/lib/session.c
@@ -171,6 +171,7 @@ void rm_session_acknowledge_abort(const gint abort_count) {
  **/
 int rm_session_dedupe_main(RmCfg *cfg) {
 #if HAVE_FIDEDUPERANGE || HAVE_BTRFS_H
+    g_assert(cfg->path_count == g_slist_length(cfg->paths));
     if(cfg->path_count != 2) {
         rm_log_error(_("Usage: rmlint --dedupe [-r] [-v|V] source dest\n"));
         return EXIT_FAILURE;
@@ -363,6 +364,7 @@ int rm_session_is_reflink_main(RmCfg *cfg) {
      * Other return values defined in utilities.h 'RmOffsetsMatchCode' enum
      */
 
+    g_assert(cfg->path_count == g_slist_length(cfg->paths));
     if(cfg->path_count != 2) {
         rm_log_error(_("Usage: rmlint --is-clone [-v|V] file1 file2\n"));
         return EXIT_FAILURE;

--- a/lib/treemerge.c
+++ b/lib/treemerge.c
@@ -184,6 +184,7 @@ static bool rm_tm_count_files(RmTrie *count_tree, const RmCfg *const cfg) {
     g_assert(cfg);
     guint path_count = cfg->path_count;
     g_assert(path_count);
+    g_assert(path_count == g_slist_length(cfg->paths));
 
     const char **const path_vec = malloc(sizeof(*path_vec) * (path_count + 1));
     if(!path_vec) {

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rmlint 2.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-27 23:04+0000\n"
+"POT-Creation-Date: 2018-10-04 18:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1017,6 +1017,10 @@ msgstr ""
 
 #: lib/treemerge.c
 msgid "Failed to allocate memory. Out of memory?"
+msgstr ""
+
+#: lib/cmdline.c
+msgid "--replay (-Y) is incompatible with --dedupe or --is-reflink"
 msgstr ""
 
 #~ msgid "%s%15"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rmlint 2.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-10-04 18:23+0000\n"
+"POT-Creation-Date: 2018-10-04 18:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1021,6 +1021,11 @@ msgstr ""
 
 #: lib/cmdline.c
 msgid "--replay (-Y) is incompatible with --dedupe or --is-reflink"
+msgstr ""
+
+#: lib/cmdline.c
+#, c-format
+msgid "No stamp file at `%s`, will create one after this run."
 msgstr ""
 
 #~ msgid "%s%15"

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rmlint 2.4.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-27 23:04+0000\n"
+"POT-Creation-Date: 2018-10-04 18:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -994,6 +994,10 @@ msgstr ""
 
 #: lib/treemerge.c
 msgid "Failed to allocate memory. Out of memory?"
+msgstr ""
+
+#: lib/cmdline.c
+msgid "--replay (-Y) is incompatible with --dedupe or --is-reflink"
 msgstr ""
 
 #~ msgid "caching is not supported due to missing json-glib library."

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rmlint 2.4.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-10-04 18:23+0000\n"
+"POT-Creation-Date: 2018-10-04 18:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -998,6 +998,11 @@ msgstr ""
 
 #: lib/cmdline.c
 msgid "--replay (-Y) is incompatible with --dedupe or --is-reflink"
+msgstr ""
+
+#: lib/cmdline.c
+#, c-format
+msgid "No stamp file at `%s`, will create one after this run."
 msgstr ""
 
 #~ msgid "caching is not supported due to missing json-glib library."

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rmlint 2.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-27 23:04+0000\n"
+"POT-Creation-Date: 2018-10-04 18:23+0000\n"
 "PO-Revision-Date: 2014-12-02 13:37+0100\n"
 "Last-Translator: F. <contact@f.0x2501.org>\n"
 "Language-Team: none\n"
@@ -990,6 +990,10 @@ msgstr ""
 
 #: lib/treemerge.c
 msgid "Failed to allocate memory. Out of memory?"
+msgstr ""
+
+#: lib/cmdline.c
+msgid "--replay (-Y) is incompatible with --dedupe or --is-reflink"
 msgstr ""
 
 #~ msgid "caching is not supported due to missing json-glib library."

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rmlint 2.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-10-04 18:23+0000\n"
+"POT-Creation-Date: 2018-10-04 18:46+0000\n"
 "PO-Revision-Date: 2014-12-02 13:37+0100\n"
 "Last-Translator: F. <contact@f.0x2501.org>\n"
 "Language-Team: none\n"
@@ -994,6 +994,11 @@ msgstr ""
 
 #: lib/cmdline.c
 msgid "--replay (-Y) is incompatible with --dedupe or --is-reflink"
+msgstr ""
+
+#: lib/cmdline.c
+#, c-format
+msgid "No stamp file at `%s`, will create one after this run."
 msgstr ""
 
 #~ msgid "caching is not supported due to missing json-glib library."

--- a/po/rmlint.pot
+++ b/po/rmlint.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rmlint 2.6.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-10-04 18:23+0000\n"
+"POT-Creation-Date: 2018-10-04 18:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -943,4 +943,9 @@ msgstr ""
 
 #: lib/cmdline.c
 msgid "--replay (-Y) is incompatible with --dedupe or --is-reflink"
+msgstr ""
+
+#: lib/cmdline.c
+#, c-format
+msgid "No stamp file at `%s`, will create one after this run."
 msgstr ""

--- a/po/rmlint.pot
+++ b/po/rmlint.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: rmlint 2.6.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-09-27 23:04+0000\n"
+"POT-Creation-Date: 2018-10-04 18:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -939,4 +939,8 @@ msgstr ""
 
 #: lib/treemerge.c
 msgid "Failed to allocate memory. Out of memory?"
+msgstr ""
+
+#: lib/cmdline.c
+msgid "--replay (-Y) is incompatible with --dedupe or --is-reflink"
 msgstr ""


### PR DESCRIPTION
This series documents and improves the usage of `RmCfg::path_count`, and then fixes a related programming mistake that manifests when mixing the aforementioned options. As an aside, the `gettext` files are also updated.