### PR TITLE
Fix nosetests search.

### DIFF
--- a/tests/SConscript
+++ b/tests/SConscript
@@ -5,15 +5,24 @@ Import('env')
 Import('programs')
 
 
+import os
 import subprocess
+
+
+def cmd_exists(cmd):
+    return any(
+        os.access(os.path.join(path, cmd), os.X_OK)
+        for path in os.environ["PATH"].split(os.pathsep)
+    )
 
 
 def run_tests(target=None, source=None, env=None):
     names = ['nosetests-3.3', 'nosetests-3', 'python3-nosetests', 'nosetests3', 'nosetests']
-    for name in names:
-        print('Found nosetests as ,,{}"'.format(name))
-        if not subprocess.call(name + ' -s -v -a !slow', shell=True):
-            Exit(0)
+    exes = [exe for exe in names if cmd_exists(exe)]
+    if any(exes):
+        name = exes[0]
+        print('Found nosetests as "{}"'.format(name))
+        Exit(subprocess.call(name + ' -s -v -a !slow', shell=True))
 
     print('Unable to find nosetests, tried these: ' + str(names))
     Exit(-1)


### PR DESCRIPTION
Avoid confusing error message about nosetests not being found when
there is a test failure.