### PR TITLE
Fix support for pre-SSE4.2 CPUs.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -663,8 +663,6 @@ else:
 
 # check _mm_crc32_u64 (SSE4.2) support:
 conf.check_mm_crc32_u64()
-if conf.env['HAVE_MM_CRC32_U64']:
-    conf.env.Append(CCFLAGS=['-msse4.2'])
 
 if 'clang' in os.path.basename(conf.env['CC']):
     conf.env.Append(CCFLAGS=['-fcolor-diagnostics'])  # Colored warnings

--- a/lib/checksums/metrohash128.c
+++ b/lib/checksums/metrohash128.c
@@ -94,6 +94,7 @@ Metro128State *metrohash128_copy(Metro128State *state) {
 
 #include <nmmintrin.h>
 
+__attribute__((target("sse4.2")))
 void metrohash128crc_1_update(Metro128State *state, const uint8_t *key, size_t len) {
     if(!state->use_sse) {
         metrohash128_1_update(state, key, len);
@@ -148,6 +149,7 @@ void metrohash128crc_2_update(Metro128State *state, const uint8_t *key, size_t l
     }
 }
 
+__attribute__((target("sse4.2")))
 void metrohash128crc_1_steal(Metro128State *state, uint8_t *out) {
     if(!state->use_sse) {
         metrohash128_1_steal(state, out);
@@ -209,6 +211,7 @@ void metrohash128crc_1_steal(Metro128State *state, uint8_t *out) {
     memcpy(out, v, 16);
 }
 
+__attribute__((target("sse4.2")))
 void metrohash128crc_2_steal(Metro128State *state, uint8_t *out) {
     if(!state->use_sse) {
         metrohash128_2_steal(state, out);


### PR DESCRIPTION
When compiled with -msse4.2 optimisation applied across the board,
'rmlint -g' terminates with the SIGILL signal on pre-SSE4.2 platforms.

It seems like GCC 8.2.0 optimises the floor function/macro call from
lib/formats/progressbar.c with illegal instructions. With Clang, even
more such optimisations occur.

Use function attributes to enable SSE4.2 feature only where required,
so that both types of CPU are fully supported.