### PR TITLE
Fix typo in command-line help

### DIFF
--- a/lib/cmdline.c
+++ b/lib/cmdline.c
@@ -1307,7 +1307,7 @@ bool rm_cmd_parse_args(int argc, char **argv, RmSession *session) {
         {"followlinks"              , 'f'  , EMPTY     , G_OPTION_ARG_CALLBACK  , FUNC(follow_symlinks)          , _("Follow symlinks")                                                      , NULL}     ,
         {"no-followlinks"           , 'F'  , DISABLE   , G_OPTION_ARG_NONE      , &cfg->follow_symlinks          , _("Ignore symlinks")                                                      , NULL}     ,
         {"paranoid"                 , 'p'  , EMPTY     , G_OPTION_ARG_CALLBACK  , FUNC(paranoid)                 , _("Use more paranoid hashing")                                            , NULL}     ,
-        {"no-crossdev"              , 'x'  , DISABLE   , G_OPTION_ARG_NONE      , &cfg->crossdev                 , _("Do not cross mounpoints")                                              , NULL}     ,
+        {"no-crossdev"              , 'x'  , DISABLE   , G_OPTION_ARG_NONE      , &cfg->crossdev                 , _("Do not cross mountpoints")                                              , NULL}     ,
         {"keep-all-tagged"          , 'k'  , 0         , G_OPTION_ARG_NONE      , &cfg->keep_all_tagged          , _("Keep all tagged files")                                                , NULL}     ,
         {"keep-all-untagged"        , 'K'  , 0         , G_OPTION_ARG_NONE      , &cfg->keep_all_untagged        , _("Keep all untagged files")                                              , NULL}     ,
         {"must-match-tagged"        , 'm'  , 0         , G_OPTION_ARG_NONE      , &cfg->must_match_tagged        , _("Must have twin in tagged dir")                                         , NULL}     ,

--- a/po/de.po
+++ b/po/de.po
@@ -713,7 +713,7 @@ msgid "Use more paranoid hashing"
 msgstr "Benutze immer paranoideren Hashalgorithmus"
 
 #: lib/cmdline.c
-msgid "Do not cross mounpoints"
+msgid "Do not cross mountpoints"
 msgstr "Überquere keine Mountpoints"
 
 #: lib/cmdline.c

--- a/po/es.po
+++ b/po/es.po
@@ -696,7 +696,7 @@ msgid "Use more paranoid hashing"
 msgstr "Usa un ratreo más paranóico"
 
 #: lib/cmdline.c
-msgid "Do not cross mounpoints"
+msgid "Do not cross mountpoints"
 msgstr "No cruza los puntos de montaje"
 
 #: lib/cmdline.c

--- a/po/fr.po
+++ b/po/fr.po
@@ -692,7 +692,7 @@ msgid "Use more paranoid hashing"
 msgstr "Utiliser une fonction de hachage paranoïaque"
 
 #: lib/cmdline.c
-msgid "Do not cross mounpoints"
+msgid "Do not cross mountpoints"
 msgstr "Ne pas traverser les points de montages"
 
 #: lib/cmdline.c

--- a/po/rmlint.pot
+++ b/po/rmlint.pot
@@ -674,7 +674,7 @@ msgid "Use more paranoid hashing"
 msgstr ""
 
 #: lib/cmdline.c
-msgid "Do not cross mounpoints"
+msgid "Do not cross mountpoints"
 msgstr ""
 
 #: lib/cmdline.c


### PR DESCRIPTION
Other places in the documentation seem to use "mountpoint" instead of "mount point", so I left it as a single word.