### PR TITLE
fix logic inversion in xattr read/write code

### DIFF
--- a/lib/xattr.c
+++ b/lib/xattr.c
@@ -265,7 +265,7 @@ gboolean rm_xattr_read_hash(RmFile *file, RmSession *session) {
         return FALSE;
     }
 
-    if(FLOAT_SIGN_DIFF(g_ascii_strtod(mtime_buf, NULL), file->mtime, MTIME_TOL) == 0) {
+    if(FLOAT_SIGN_DIFF(g_ascii_strtod(mtime_buf, NULL), file->mtime, MTIME_TOL) != 0) {
         /* Data is too old and not useful, autoclean it */
         RM_DEFINE_PATH(file);
         rm_log_debug_line("Checksum too old for %s, %" G_GINT64_FORMAT " < %" G_GINT64_FORMAT,


### PR DESCRIPTION
Fixes #347.

On debugging, the root cause appeared to be a simple logic inversion in some of the mtime logic.