### PR TITLE
added another check for HAVE_XATTR in xattr.c

### DIFF
--- a/lib/xattr.c
+++ b/lib/xattr.c
@@ -312,6 +312,8 @@ int rm_xattr_clear_hash(RmFile *file, RmSession *session) {
 #endif
 }
 
+#if HAVE_XATTR
+
 GHashTable *rm_xattr_list(const char *path, bool follow_symlinks) {
     const size_t buf_size = 4096;
     const size_t val_size = 1024;
@@ -480,3 +482,5 @@ int rm_xattr_mark_deduplicated(const char *path, bool follow_symlinks) {
     g_hash_table_destroy(map);
     return result;
 }
+
+#endif


### PR DESCRIPTION
without this check for HAVE_XATTR, build fails for systems that don't have sys/xattr.h
I'm working on a nice FreeBSD port and stumbled upon this.