### PR TITLE
Remove use of GLib API calls deprecated since version 2.62.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -611,7 +611,7 @@ conf.check_pkgconfig('0.15.0')
 
 # Pkg-config to internal name
 conf.env['HAVE_GLIB'] = 0
-conf.check_pkg('glib-2.0 >= 2.32', 'HAVE_GLIB', required=True)
+conf.check_pkg('glib-2.0 >= 2.62', 'HAVE_GLIB', required=True)
 
 conf.env['HAVE_GIO_UNIX'] = 0
 conf.check_pkg('gio-unix-2.0', 'HAVE_GIO_UNIX', required=False)

--- a/lib/formats.c
+++ b/lib/formats.c
@@ -208,12 +208,12 @@ void rm_fmt_clear(RmFmtTable *self) {
 }
 
 void rm_fmt_backup_old_result_file(RmFmtTable *self, const char *old_path) {
-    if(self->first_backup_timestamp.tv_sec == 0L) {
-        g_get_current_time(&self->first_backup_timestamp);
+    if(self->first_backup_timestamp == NULL) {
+        self->first_backup_timestamp = g_date_time_new_now_utc();
     }
 
     char *new_path = NULL;
-    char *timestamp = g_time_val_to_iso8601(&self->first_backup_timestamp);
+    char *timestamp = rm_iso8601_format_date_time(self->first_backup_timestamp);
 
     // Split the extension, if possible and place it before the timestamp suffix.
     char *extension = g_utf8_strrchr(old_path, -1, '.');
@@ -442,6 +442,9 @@ void rm_fmt_close(RmFmtTable *self) {
     g_hash_table_unref(self->handler_set);
     g_queue_free(self->handler_order);
     g_rec_mutex_clear(&self->state_mtx);
+    if(self->first_backup_timestamp != NULL) {
+        g_date_time_unref(self->first_backup_timestamp);
+    }
     g_slice_free(RmFmtTable, self);
 }
 

--- a/lib/formats.h
+++ b/lib/formats.h
@@ -59,7 +59,7 @@ typedef struct RmFmtTable {
     GQueue *handler_order;
     GRecMutex state_mtx;
     RmSession *session;
-    GTimeVal first_backup_timestamp;
+    GDateTime *first_backup_timestamp;
 
     /* Group of RmFiles that will be cached until exit */
     GQueue groups;

--- a/lib/utilities.h
+++ b/lib/utilities.h
@@ -452,6 +452,15 @@ gdouble rm_iso8601_parse(const char *string);
  */
 bool rm_iso8601_format(time_t stamp, char *buf, gsize buf_size);
 
+/**
+ * @brief convert GDateTime as iso8601 timestamp string with unrounded seconds.
+ *
+ * @param date_time pointer to GLib date time object.
+ *
+ * @return non-null string if conversion succeeded.
+ */
+gchar *rm_iso8601_format_date_time(GDateTime *date_time) G_GNUC_MALLOC;
+
 ///////////////////////////////
 //    THREADPOOL HELPERS     //
 ///////////////////////////////


### PR DESCRIPTION
Replace deprecated GTimeVal with GDateTime equivalent API calls.

Only if you no longer need to support versions of GLib older than this.