### PR TITLE
Shellcheck cleanup

### DIFF
--- a/.format.sh
+++ b/.format.sh
@@ -3,11 +3,11 @@
 FILES=$(find src lib -iname '*.[ch]')
 
 # Format the files according to the style defined in .clang-format
-clang-format -i -style=file "${FILES}" || (echo 'clang-format failed'; exit 1);
+clang-format -i -style=file ${FILES} || (echo 'clang-format failed'; exit 1);
 
 # clang-format sometimes adds windows like line-endins (\r\n).
 # Fix this by issueing dos2unix on every file.
-dos2unix --quiet "${FILES}" || (echo 'dos2unix failed'; exit 2);
+dos2unix --quiet ${FILES} || (echo 'dos2unix failed'; exit 2);
 
 # Some bad editors might save files with a bad encoding.
 # Since a few source code files contain unicode, we fix this with iconv.

--- a/.format.sh
+++ b/.format.sh
@@ -3,16 +3,16 @@
 FILES=$(find src lib -iname '*.[ch]')
 
 # Format the files according to the style defined in .clang-format
-clang-format -i -style=file ${FILES} || (echo 'clang-format failed'; exit 1);
+clang-format -i -style=file "${FILES}" || (echo 'clang-format failed'; exit 1);
 
 # clang-format sometimes adds windows like line-endins (\r\n).
-# Fix this by issueing dos2unix on every file. 
-dos2unix --quiet ${FILES} || (echo 'dos2unix failed'; exit 2);
+# Fix this by issueing dos2unix on every file.
+dos2unix --quiet "${FILES}" || (echo 'dos2unix failed'; exit 2);
 
-# Some bad editors might save files with a bad encoding. 
+# Some bad editors might save files with a bad encoding.
 # Since a few source code files contain unicode, we fix this with iconv.
-for path in ${FILES}; do 
+for path in ${FILES}; do
     # iconv core dumps when using the same file as input and output.
     # (adding this to my wtf-of-the-day-list)
-    cat ${path} | iconv -t "utf-8" -o ${path} || (echo "iconv failed on ${path}"; exit 3)
-done; 
+    iconv -t "utf-8" -o "${path}" < "${path}" || (echo "iconv failed on ${path}"; exit 3)
+done;

--- a/.format.sh
+++ b/.format.sh
@@ -12,7 +12,12 @@ dos2unix --quiet "${FILES}" || (echo 'dos2unix failed'; exit 2);
 # Some bad editors might save files with a bad encoding.
 # Since a few source code files contain unicode, we fix this with iconv.
 for path in ${FILES}; do
-    # iconv core dumps when using the same file as input and output.
-    # (adding this to my wtf-of-the-day-list)
-    iconv -t "utf-8" -o "${path}" < "${path}" || (echo "iconv failed on ${path}"; exit 3)
+    tmpfile=$(mktemp 'rmlint.XXXXXXXX.utf8')
+    if iconv -t "utf-8" -o "$tmpfile" < "${path}" ; then
+      mv "$tmpfile" "${path}"
+    else
+      echo "iconv failed on ${path}" 1>&2
+      rm -f "$tmpfile"
+      exit 3
+    fi
 done;

--- a/lib/formats/sh.sh
+++ b/lib/formats/sh.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 PROGRESS_CURR=0
-PROGRESS_TOTAL=0                           
+PROGRESS_TOTAL=0
 
 # This file was autowritten by rmlint
 # rmlint was executed from: %s
@@ -255,19 +255,19 @@ remove_cmd() {
     echo "${COL_YELLOW}Deleting: ${COL_RESET}$1"
     if original_check "$1" "$2"; then
         if [ -z "$DO_DRY_RUN" ]; then
-            if [ ! -z "$DO_KEEP_DIR_TIMESTAMPS" ]; then
-                touch -r "$(dirname $1)" "$STAMPFILE"
+            if [ -n "$DO_KEEP_DIR_TIMESTAMPS" ]; then
+                touch -r "$(dirname "$1")" "$STAMPFILE"
             fi
 
             rm -rf "$1"
 
-            if [ ! -z "$DO_KEEP_DIR_TIMESTAMPS" ]; then
+            if [ -n "$DO_KEEP_DIR_TIMESTAMPS" ]; then
                 # Swap back old directory timestamp:
-                touch -r "$STAMPFILE" "$(dirname $1)"
+                touch -r "$STAMPFILE" "$(dirname "$1")"
                 rm "$STAMPFILE"
             fi
 
-            if [ ! -z "$DO_DELETE_EMPTY_DIRS" ]; then
+            if [ -n "$DO_DELETE_EMPTY_DIRS" ]; then
                 DIR=$(dirname "$1")
                 while [ ! "$(ls -A "$DIR")" ]; do
                     print_progress_prefix 0
@@ -382,7 +382,7 @@ then
   ask
 fi
 
-if [ ! -z $DO_DRY_RUN  ]
+if [ -n "$DO_DRY_RUN" ]
 then
     echo "#${COL_YELLOW} ////////////////////////////////////////////////////////////${COL_RESET}"
     echo "#${COL_YELLOW} /// ${COL_RESET} This is only a dry run; nothing will be modified! ${COL_YELLOW}///${COL_RESET}"

--- a/lib/formats/sh.sh
+++ b/lib/formats/sh.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 PROGRESS_CURR=0
-PROGRESS_TOTAL=0
+PROGRESS_TOTAL=0                           
 
 # This file was autowritten by rmlint
 # rmlint was executed from: %s


### PR DESCRIPTION
This fixes [shellcheck](https://shellcheck.net) linter errors and fixes a problem with how `iconv` is being invoked, which was referenced in the comments.

shellcheck's [SC2094](https://github.com/koalaman/shellcheck/wiki/SC2094) explains the problem with the code as it was.