### PR TITLE
Escape contents of 'parent_path' JSON field

### DIFF
--- a/lib/formats/json.c
+++ b/lib/formats/json.c
@@ -347,7 +347,7 @@ static void rm_fmt_elem(RmSession *session, _UNUSED RmFmtHandler *parent, FILE *
 
 
 			if(file->lint_type == RM_LINT_TYPE_PART_OF_DIRECTORY && file->parent_dir) {
-				rm_fmt_json_key(out, "parent_path", rm_directory_get_dirname(file->parent_dir));
+				rm_fmt_json_key_unsafe(out, "parent_path", rm_directory_get_dirname(file->parent_dir));
 				rm_fmt_json_sep(self, out);
 
 			}


### PR DESCRIPTION
Just ran:

`rmlint . -D -T minimaldirs`

and some of the JSON produced was broken, namely any time a 'part_of_directory' record was generated for a path that had something goofy like one double-quote in it, the 'path' field was escaped properly but the 'parent_path' field was not.  The 'path' field output is escaped via 'rm_fmt_json_key_unsafe', whereas the 'parent_path' field just uses 'rm_fmt_json_key'.  Probably both ought to use _unsafe.