### PR TITLE
test_formatter: sh: check whether file still exists

### DIFF
--- a/tests/test_formatters/test_sh.py
+++ b/tests/test_formatters/test_sh.py
@@ -95,6 +95,12 @@ def test_paranoia(shell):
     sh_script = os.path.join(TESTDIR_NAME, 'rmlint.sh')
     text = run_shell_script(shell, sh_script, '-d', '-p', '-x')
 
+    assert 'files no longer identical' in text
+
+    # Check that file contents of c are still intact
+    with open(os.path.join(TESTDIR_NAME, 'c'), 'r') as handle:
+        assert handle.read() == 'xxxx'
+
     # Change back 'c':
     with open(os.path.join(TESTDIR_NAME, 'c'), 'w') as handle:
         handle.write('xxx')
@@ -108,7 +114,6 @@ def test_paranoia(shell):
     assert footer['total_files'] == 2 # +1
     assert footer['duplicates'] == 1
 
-    assert 'files no longer identical' in text
 
     # Remove original:
     os.remove(os.path.join(TESTDIR_NAME, 'a'))


### PR DESCRIPTION
Before b9d328be2041e42813119d060c86893853b8e250 "-p" (aka paranoid mode) deleted files even if the original file differed from the (not anymore) duplicate.

This wasn't captured by the test due to the following reasons:

- the expected error message was included in rmlint's output
- Python's "open(..., 'w')" command creates the given file anew

To make sure that our file is still sane and sound, we need to reread it from the drive and survey its content.

----

To test this pull request, I've used `scons test` on `develop` on the current `HEAD` but also on the old `sh.sh` variant:

```sh
scons test # runs fine
cat > remove-check.patch << 'EOF'
diff --git a/lib/formats/sh.sh b/lib/formats/sh.sh
index b5e495d5..39ed3b99 100644
--- a/lib/formats/sh.sh
+++ b/lib/formats/sh.sh
@@ -160,7 +160,6 @@ original_check() {
     else
         if ! check_for_equality "$1" "$2"; then
             printf "${COL_RED}^^^^^^ Error: files no longer identical - cancelling.....${COL_RESET}\n"
-            return 1
         fi
     fi
 }
EOF
git apply remove-check.patch
scons test # fails as expected with new test
```
| |old test|new test|
|-|-|-|
|before b9d328be2041e42813119d060c86893853b8e250 |**pass**, ***but `c` is deleted!***|**fails**, because `c` is deleted|
|after b9d328be2041e42813119d060c86893853b8e250 |**pass**, but `c` is not checked for deletion/change| **pass**|

I hope that this variant of `test_paranoia` makes rmlint a more robust. Thanks for your work on an amazing tool!

Fixes #454 
