### PR TITLE
fix issue #385

### DIFF
--- a/lib/replay.c
+++ b/lib/replay.c
@@ -738,13 +738,14 @@ static void rm_parrot_cage_write_group(RmParrotCage *cage, GQueue *group, bool p
     for(GList *iter = group->head; iter; iter = iter->next) {
         RmFile *file = iter->data;
 
-        if(file == group->head->data
+        // just use "is_original" value from json
+        /*if(file == group->head->data
         || (cfg->keep_all_tagged && file->is_prefd)
         || (cfg->keep_all_untagged && !file->is_prefd)) {
             file->is_original = true;
         } else {
             file->is_original = false;
-        }
+        }*/
 
         /* Other lint never should bother for is_original,
          * since this definition doesn't make sense there.


### PR DESCRIPTION
I hope I find a solution of the issue #385.

current behavior:

1. reads json properties
2. overwrites "is_original" prop to first-in-the-duplicate group

suggested behavior:

1. reads json properties
2. keeps "is_original" prop unchanged (due to gui "shredder" overwrites it to save manually toggled files)
