### PR TITLE
Glib json

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -515,7 +515,7 @@ AddOption(
     action='store', metavar='DIR', help='libdir name (lib or lib64)'
 )
 
-for suffix in ['libelf', 'gettext', 'fiemap', 'blkid', 'json-glib', 'gui']:
+for suffix in ['libelf', 'gettext', 'fiemap', 'blkid', 'gui']:
     AddOption(
         '--without-' + suffix, action='store_const', default=False, const=False,
         dest='with_' + suffix
@@ -599,17 +599,11 @@ conf.env['HAVE_BLKID'] = 0
 conf.check_pkg('blkid', 'HAVE_BLKID', required=False)
 
 conf.env['HAVE_JSON_GLIB'] = 0
-conf.check_pkg('json-glib-1.0', 'HAVE_JSON_GLIB', required=False)
+conf.check_pkg('json-glib-1.0', 'HAVE_JSON_GLIB', required=True)
 
-if GetOption('with_json-glib') is False:
-    conf.env['HAVE_JSON_GLIB'] = 0
-
-packages = ['glib-2.0']
+packages = ['glib-2.0', 'json-glib-1.0']
 if conf.env['HAVE_BLKID']:
     packages.append('blkid')
-
-if conf.env['HAVE_JSON_GLIB']:
-    packages.append('json-glib-1.0')
 
 if conf.env['HAVE_GIO_UNIX']:
     packages.append('gio-unix-2.0')
@@ -885,7 +879,6 @@ if 'config' in COMMAND_LINE_TARGETS:
     Support for SHA512 (needs glib >= 2.31)               : {sha512}
     Build manpage from docs/rmlint.1.rst                  : {sphinx}
     Support for caching checksums in file's xattr         : {xattr}
-    Support for reading json caches (needs json-glib)     : {json_glib}
     Checking for proper support of big files >= 4GB       : {bigfiles}
         (needs either sizeof(off_t) >= 8 ...)             : {bigofft}
         (... or presence of stat64)                       : {bigstat}
@@ -916,7 +909,6 @@ Type 'scons' to actually compile rmlint now. Good luck.
             locale=yesno(env['HAVE_LIBINTL']),
             msgfmt=yesno(env['HAVE_MSGFMT']),
             xattr=yesno(env['HAVE_XATTR']),
-            json_glib=yesno(env['HAVE_JSON_GLIB']),
             nonrotational=yesno(env['HAVE_GIO_UNIX'] & env['HAVE_BLKID']),
             gio_unix=yesno(env['HAVE_GIO_UNIX']),
             blkid=yesno(env['HAVE_BLKID']),

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -198,11 +198,6 @@ Arguments
     Do not link with ``libblkid``, which is needed to differentiate between
     normal rotational harddisks and non-rotational disks.
 
-:--without-json-glib:
-
-    Do not link with ``libjson-glib``, which is needed to load json-cache files.
-    Without this library a warning is printed when using ``--replay``.
-
 :--without-fiemap:
 
     Do not attempt to use the ``FIEMAP ioctl(2)``. 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -16,13 +16,13 @@ Hard dependencies:
 ~~~~~~~~~~~~~~~~~~
 
 * **glib** :math:`\geq 2.32` (general C Utility Library)
+* **libjson-glib** (parsing rmlint's own json as caching layer)
 
 Soft dependencies:
 ~~~~~~~~~~~~~~~~~~
 
 * **libblkid** (detecting mountpoints)
 * **libelf** (nonstripped binary detection)
-* **libjson-glib** (parsing rmlint's own json as caching layer)
 
 Build dependencies:
 ~~~~~~~~~~~~~~~~~~~

--- a/gui/shredder/application.py
+++ b/gui/shredder/application.py
@@ -79,13 +79,6 @@ class Application(Gtk.Application):
         self.cmd_opts = options
         self.settings = self.win = None
 
-        # Check compile time features of rmlint that we need later.
-        if not have_feature('replay'):
-            LOGGER.error('No support for +replay in rmlint binary.')
-            LOGGER.error('Please recompile with --with-json-glib…')
-            LOGGER.error('…and `json-glib-1.0` installed on your system.')
-            sys.exit(-1)
-
     def do_activate(self, **kw):
         Gtk.Application.do_activate(self, **kw)
         self.win.present()

--- a/lib/SConscript
+++ b/lib/SConscript
@@ -20,7 +20,6 @@ def build_config_template(target, source, env):
             INSTALL_PREFIX=GetOption('actual_prefix') or GetOption('prefix'),
             HAVE_LIBINTL=env['HAVE_GETTEXT'],
             HAVE_LIBELF=env['HAVE_LIBELF'],
-            HAVE_JSON_GLIB=env['HAVE_JSON_GLIB'],
             HAVE_GIO_UNIX=env['HAVE_GIO_UNIX'],
             HAVE_FIEMAP=env['HAVE_FIEMAP'],
             HAVE_XATTR=env['HAVE_XATTR'],

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -93,6 +93,7 @@ typedef struct RmCfg {
     gboolean read_stdin;
     gboolean read_stdin0;
     gboolean backup;
+    gboolean hash_uniques;
 
     int permissions;
 

--- a/lib/cmdline.c
+++ b/lib/cmdline.c
@@ -75,7 +75,6 @@ static void rm_cmd_show_version(void) {
                     {.name = "sha512",         .enabled = HAVE_SHA512},
                     {.name = "bigfiles",       .enabled = HAVE_BIGFILES},
                     {.name = "intl",           .enabled = HAVE_LIBINTL},
-                    {.name = "replay",         .enabled = HAVE_JSON_GLIB},
                     {.name = "xattr",          .enabled = HAVE_XATTR},
                     {.name = "btrfs-support",  .enabled = HAVE_BTRFS_H},
                     {.name = NULL,             .enabled = 0}};

--- a/lib/cmdline.c
+++ b/lib/cmdline.c
@@ -1488,6 +1488,7 @@ bool rm_cmd_parse_args(int argc, char **argv, RmSession *session) {
         {"threads"                , 't' , HIDDEN           , G_OPTION_ARG_INT64    , &cfg->threads                , "Specify max. number of hasher threads"                       , "N"}    ,
         {"threads-per-disk"       , 0   , HIDDEN           , G_OPTION_ARG_INT      , &cfg->threads_per_disk       , "Specify number of reader threads per physical disk"          , NULL}   ,
         {"write-unfinished"       , 'U' , HIDDEN           , G_OPTION_ARG_NONE     , &cfg->write_unfinished       , "Output unfinished checksums"                                 , NULL}   ,
+        {"hash-uniques"           , 0   , HIDDEN           , G_OPTION_ARG_NONE     , &cfg->hash_uniques           , "Hash (whole of) unique files too (for json or xattr output)" , NULL}   ,
         {"xattr-write"            , 0   , HIDDEN           , G_OPTION_ARG_NONE     , &cfg->write_cksum_to_xattr   , "Cache checksum in file attributes"                           , NULL}   ,
         {"xattr-read"             , 0   , HIDDEN           , G_OPTION_ARG_NONE     , &cfg->read_cksum_from_xattr  , "Read cached checksums from file attributes"                  , NULL}   ,
         {"xattr-clear"            , 0   , HIDDEN           , G_OPTION_ARG_NONE     , &cfg->clear_xattr_fields     , "Clear xattrs from all seen files"                            , NULL}   ,

--- a/lib/config.h.in
+++ b/lib/config.h.in
@@ -6,7 +6,6 @@
 #define HAVE_BLKID         ({HAVE_BLKID})
 #define HAVE_LIBINTL       ({HAVE_LIBINTL})
 #define HAVE_LIBELF        ({HAVE_LIBELF})
-#define HAVE_JSON_GLIB     ({HAVE_JSON_GLIB})
 #define HAVE_GIO_UNIX      ({HAVE_GIO_UNIX})
 #define HAVE_FIEMAP        ({HAVE_FIEMAP})
 #define HAVE_XATTR         ({HAVE_XATTR})

--- a/lib/formats/json.c
+++ b/lib/formats/json.c
@@ -1,4 +1,4 @@
-/*
+	/*
  *  This file is part of rmlint.
  *
  *  rmlint is free software: you can redistribute it and/or modify
@@ -30,18 +30,24 @@
 #include "../treemerge.h"
 
 #include <glib.h>
+#include <json-glib/json-glib.h>
+#include <gio/gunixoutputstream.h>
 #include <stdio.h>
 #include <string.h>
+#include <assert.h>
 
 typedef struct RmFmtHandlerJSON {
     /* must be first */
     RmFmtHandler parent;
 
-    /* More human readable output? */
-    bool pretty;
-
     /* set of already existing ids */
     GHashTable *id_set;
+
+    GOutputStream *stream;
+    JsonGenerator *generator;
+    JsonNode *root;
+    JsonArray *array;
+
 } RmFmtHandlerJSON;
 
 //////////////////////////////////////////
@@ -73,190 +79,98 @@ static guint32 rm_fmt_json_generate_id(RmFmtHandlerJSON *self, RmFile *file,
 //  POOR MAN'S JSON FORMATTING TOOLBOX  //
 //////////////////////////////////////////
 
-static void rm_fmt_json_key(FILE *out, const char *key, const char *value) {
-    fprintf(out, "\"%s\": \"%s\"", key, value);
+
+static void rm_fmt_json_open(RmSession *session, RmFmtHandlerJSON *self, FILE *out) {
+    self->stream = g_unix_output_stream_new(fileno(out), false);
+    self->generator = json_generator_new ();
+    json_generator_set_pretty(self->generator, !rm_fmt_get_config_value(session->formats, "json", "oneline"));
+
+
+    json_generator_set_root(self->generator, json_node_alloc());
+    self->root = json_generator_get_root(self->generator);
+    self->array = json_array_new();
+    json_node_init_array(self->root, self->array);
+
+
+    self->id_set = g_hash_table_new(NULL, NULL);
 }
 
-static void rm_fmt_json_key_bool(FILE *out, const char *key, bool value) {
-    fprintf(out, "\"%s\": %s", key, value ? "true" : "false");
-}
+static void rm_fmt_json_close(RmFmtHandlerJSON *self) {
 
-static void rm_fmt_json_key_int(FILE *out, const char *key, RmOff value) {
-    fprintf(out, "\"%s\": %" LLU "", key, value);
-}
-
-static void rm_fmt_json_key_float(FILE *out, const char *key, gdouble value) {
-    // Make sure that the floating point number gets printed with a '.',
-    // not with a comma as usual in e.g. the german language.
-    gchar buf[G_ASCII_DTOSTR_BUF_SIZE];
-    fprintf(out, "\"%s\": %s", key, g_ascii_dtostr(buf, sizeof(buf) - 1, value));
-}
-
-static bool rm_fmt_json_fix(const char *string, char *fixed, size_t fixed_len) {
-    /* More information here:
-     *
-     * http://stackoverflow.com/questions/4901133/json-and-escaping-characters/4908960#4908960
-     */
-
-    int n = strlen(string);
-    char *safe_iter = fixed;
-
-    for(int i = 0; i < n && (size_t)(safe_iter - fixed) < fixed_len; ++i) {
-        unsigned char *curr = (unsigned char *)&string[i];
-
-        char text[20];
-        memset(text, 0, sizeof(text));
-
-        if(*curr == '"' || *curr == '\\') {
-            /* Printable, but needs to be escaped */
-            text[0] = '\\';
-            text[1] = *curr;
-        } else if((*curr > 0 && *curr < 0x1f) || *curr == 0x7f) {
-            /* Something unprintable */
-            switch(*curr) {
-            case '\b':
-                g_snprintf(text, sizeof(text), "\\b");
-                break;
-            case '\f':
-                g_snprintf(text, sizeof(text), "\\f");
-                break;
-            case '\n':
-                g_snprintf(text, sizeof(text), "\\n");
-                break;
-            case '\r':
-                g_snprintf(text, sizeof(text), "\\r");
-                break;
-            case '\t':
-                g_snprintf(text, sizeof(text), "\\t");
-                break;
-            default:
-                g_snprintf(text, sizeof(text), "\\u00%02x", (guint)*curr);
-                break;
-            }
-        } else {
-            /* Take it unmodified */
-            text[0] = *curr;
-        }
-
-        safe_iter = g_stpcpy(safe_iter, text);
+    // write the json to file
+    GError *error = NULL;
+    rm_log_warning_line("Writing json output, may take a while...");
+    if(!json_generator_to_stream(self->generator, self->stream, false, &error)) {
+        rm_log_error_line("Error writing to json stream");
     }
 
-    return (size_t)(safe_iter - fixed) < fixed_len;
+    g_hash_table_unref(self->id_set);
+
 }
 
-static void rm_fmt_json_key_unsafe(FILE *out, const char *key, const char *value) {
-    char safe_value[PATH_MAX + 4 + 1];
-    memset(safe_value, 0, sizeof(safe_value));
 
-    if(rm_fmt_json_fix(value, safe_value, sizeof(safe_value))) {
-        fprintf(out, "\"%s\": \"%s\"", key, safe_value);
-    } else {
-        /* This should never happen but give at least means of debugging */
-        fprintf(out, "\"%s\": \"<BROKEN PATH>\"", key);
-    }
-}
-
-static void rm_fmt_json_open(RmFmtHandlerJSON *self, FILE *out) {
-    fprintf(out, "{%s", self->pretty ? "\n  " : "");
-}
-
-static void rm_fmt_json_close(RmFmtHandlerJSON *self, FILE *out) {
-    if(self->pretty) {
-        fprintf(out, "\n}, ");
-    } else {
-        fprintf(out, "},\n");
-    }
-}
-
-static void rm_fmt_json_sep(RmFmtHandlerJSON *self, FILE *out) {
-    fprintf(out, ",%s", self->pretty ? "\n  " : "");
-}
 
 /////////////////////////
 //  ACTUAL CALLBACKS   //
 /////////////////////////
 
-static void rm_fmt_head(RmSession *session, _UNUSED RmFmtHandler *parent, FILE *out) {
-    fprintf(out, "[\n");
+static void rm_fmt_head(RmSession *session, RmFmtHandler *parent, FILE *out) {
 
     RmFmtHandlerJSON *self = (RmFmtHandlerJSON *)parent;
-    self->id_set = g_hash_table_new(NULL, NULL);
 
-    if(rm_fmt_get_config_value(session->formats, "json", "oneline")) {
-        self->pretty = false;
-    }
+    rm_fmt_json_open(session, self, out);
 
     if(!rm_fmt_get_config_value(session->formats, "json", "no_header")) {
-        rm_fmt_json_open(self, out);
-        {
-            rm_fmt_json_key(out, "description", "rmlint json-dump of lint files");
-            rm_fmt_json_sep(self, out);
-            rm_fmt_json_key(out, "cwd", session->cfg->iwd);
-            rm_fmt_json_sep(self, out);
-            rm_fmt_json_key(out, "args", session->cfg->joined_argv);
-            rm_fmt_json_sep(self, out);
-            rm_fmt_json_key(out, "version", RM_VERSION);
-            rm_fmt_json_sep(self, out);
-            rm_fmt_json_key(out, "rev", RM_VERSION_GIT_REVISION);
-            rm_fmt_json_sep(self, out);
-            rm_fmt_json_key_int(out, "progress", 0); /* Header is always first. */
-            rm_fmt_json_sep(self, out);
-            rm_fmt_json_key(out, "checksum_type",
-                            rm_digest_type_to_string(session->cfg->checksum_type));
-            if(session->hash_seed) {
-                rm_fmt_json_sep(self, out);
-                rm_fmt_json_key_int(out, "hash_seed", session->hash_seed);
-            }
 
-            rm_fmt_json_sep(self, out);
-            rm_fmt_json_key_bool(out, "merge_directories", session->cfg->merge_directories);
+        JsonObject *header = json_object_new();
+        json_object_set_string_member (header, "description", "rmlint json-dump of lint files");
+        json_object_set_string_member (header, "cwd", session->cfg->iwd);
+        json_object_set_string_member (header, "args", session->cfg->joined_argv);
+        json_object_set_string_member (header, "version", RM_VERSION);
+        json_object_set_string_member (header, "rev", RM_VERSION_GIT_REVISION);
+        json_object_set_int_member (header, "progress", 0); /* Header is always first. */
+        json_object_set_string_member (header, "checksum_type",
+                            rm_digest_type_to_string(session->cfg->checksum_type));
+        if(session->hash_seed) {
+            json_object_set_int_member(header, "hash_seed", session->hash_seed);
         }
-        rm_fmt_json_close(self, out);
+        json_object_set_boolean_member (header, "merge_directories", session->cfg->merge_directories);
+
+        json_array_add_object_element(self->array, header);
+
     }
 }
 
-static void rm_fmt_foot(_UNUSED RmSession *session, RmFmtHandler *parent, FILE *out) {
+static void rm_fmt_foot(_UNUSED RmSession *session, RmFmtHandler *parent, _UNUSED FILE *out) {
     RmFmtHandlerJSON *self = (RmFmtHandlerJSON *)parent;
 
-    if(rm_fmt_get_config_value(session->formats, "json", "no_footer")) {
-        fprintf(out, "{}");
-    } else {
-        rm_fmt_json_open(self, out);
-        {
-            rm_fmt_json_key_bool(out, "aborted", rm_session_was_aborted());
-            rm_fmt_json_sep(self, out);
-            rm_fmt_json_key_int(out, "progress", 100); /* Footer is always last. */
-            rm_fmt_json_sep(self, out);
-            rm_fmt_json_key_int(out, "total_files", session->total_files);
-            rm_fmt_json_sep(self, out);
-            rm_fmt_json_key_int(out, "ignored_files", session->ignored_files);
-            rm_fmt_json_sep(self, out);
-            rm_fmt_json_key_int(out, "ignored_folders", session->ignored_folders);
-            rm_fmt_json_sep(self, out);
-            rm_fmt_json_key_int(out, "duplicates", session->dup_counter);
-            rm_fmt_json_sep(self, out);
-            rm_fmt_json_key_int(out, "duplicate_sets", session->dup_group_counter);
-            rm_fmt_json_sep(self, out);
-            rm_fmt_json_key_int(out, "total_lint_size", session->total_lint_size);
-        }
-        if(self->pretty) {
-            fprintf(out, "\n}");
-        } else {
-            fprintf(out, "}\n");
-        }
+    if(!rm_fmt_get_config_value(session->formats, "json", "no_footer")) {
+        JsonObject *footer = json_object_new();
+        json_object_set_boolean_member(footer, "aborted", rm_session_was_aborted());
+        json_object_set_int_member(footer, "progress", 100); /* Footer is always last. */
+        json_object_set_int_member(footer, "total_files", session->total_files);
+        json_object_set_int_member(footer, "ignored_files", session->ignored_files);
+        json_object_set_int_member(footer, "ignored_folders", session->ignored_folders);
+        json_object_set_int_member(footer, "duplicates", session->dup_counter);
+        json_object_set_int_member(footer, "duplicate_sets", session->dup_group_counter);
+        json_object_set_int_member(footer, "total_lint_size", session->total_lint_size);
+        json_array_add_object_element(self->array, footer);
     }
-
-    fprintf(out, "]\n");
-    g_hash_table_unref(self->id_set);
+    rm_fmt_json_close(self);
 }
 
-static void rm_fmt_json_cksum(RmFile *file, char *checksum_str, size_t size) {
-    memset(checksum_str, '0', size);
-    checksum_str[size - 1] = 0;
+static char* rm_fmt_json_cksum(RmFile *file) {
+    if(file->digest == NULL) {
+        return NULL;
+    }
+    size_t checksum_size = rm_digest_get_bytes(file->digest) * 2 + 1;
+    char *checksum_str = g_malloc0(checksum_size);
     rm_digest_hexstring(file->digest, checksum_str);
+    checksum_str[checksum_size - 1] = 0;
+    return checksum_str;
 }
 
-static void rm_fmt_elem(RmSession *session, _UNUSED RmFmtHandler *parent, FILE *out, RmFile *file) {
+static void rm_fmt_elem(RmSession *session, _UNUSED RmFmtHandler *parent, _UNUSED FILE *out, RmFile *file) {
     if(rm_fmt_get_config_value(session->formats, "json", "no_body")) {
         return;
     }
@@ -278,106 +192,72 @@ static void rm_fmt_elem(RmSession *session, _UNUSED RmFmtHandler *parent, FILE *
             file->is_original = true;
         }
     }
-
-    char *checksum_str = NULL;
-    size_t checksum_size = 0;
-
-    if(file->digest != NULL) {
-        checksum_size = rm_digest_get_bytes(file->digest) * 2 + 1;
-        checksum_str = g_slice_alloc0(checksum_size);
-        rm_fmt_json_cksum(file, checksum_str, checksum_size);
-        checksum_str[checksum_size - 1] = 0;
-    }
+    char *checksum_str = rm_fmt_json_cksum(file);
 
     RmFmtHandlerJSON *self = (RmFmtHandlerJSON *)parent;
 
-    /* Make it look like a json element */
-    rm_fmt_json_open(self, out);
-    {
-        RM_DEFINE_PATH(file);
 
-        rm_fmt_json_key_int(out, "id",
+    RM_DEFINE_PATH(file);
+
+    JsonObject *elem = json_object_new();
+    json_object_set_int_member(elem, "id",
                             rm_fmt_json_generate_id(self, file, file_path, checksum_str));
-        rm_fmt_json_sep(self, out);
-        rm_fmt_json_key(out, "type", rm_file_lint_type_to_string(file->lint_type));
-        rm_fmt_json_sep(self, out);
-
-        gdouble progress = 0;
-        if(session->shred_bytes_after_preprocess) {
-            progress = CLAMP(
-                100 - 100 * (
-                    (gdouble)session->shred_bytes_remaining /
-                    (gdouble)session->shred_bytes_after_preprocess
-                ),
-                0,
-                100
+    json_object_set_string_member(elem, "type", rm_file_lint_type_to_string(file->lint_type));
+    gdouble progress = 0;
+    if(session->shred_bytes_after_preprocess) {
+        progress = CLAMP(
+            100 - 100 * (
+                (gdouble)session->shred_bytes_remaining /
+                (gdouble)session->shred_bytes_after_preprocess
+            ),
+            0,
+            100
             );
-        }
-        rm_fmt_json_key_int(out, "progress", progress);
-        rm_fmt_json_sep(self, out);
+        json_object_set_int_member(elem, "progress", progress);
+    }
 
-        if(file->digest) {
-            rm_fmt_json_key(out, "checksum", checksum_str);
-            rm_fmt_json_sep(self, out);
-        }
-
-        rm_fmt_json_key_unsafe(out, "path", file_path);
-        rm_fmt_json_sep(self, out);
-        rm_fmt_json_key_int(out, "size", file->actual_file_size);
-        rm_fmt_json_sep(self, out);
-        rm_fmt_json_key_int(out, "depth", file->depth);
-        rm_fmt_json_sep(self, out);
-        rm_fmt_json_key_int(out, "inode", file->inode);
-        rm_fmt_json_sep(self, out);
-        rm_fmt_json_key_int(out, "disk_id", file->dev);
-        rm_fmt_json_sep(self, out);
-        rm_fmt_json_key_bool(out, "is_original", file->is_original);
-        rm_fmt_json_sep(self, out);
+    if(file->digest) {
+        json_object_set_string_member(elem, "checksum", checksum_str);
+        json_object_set_string_member(elem, "path", file_path);
+        json_object_set_int_member(elem, "size", file->actual_file_size);
+        json_object_set_int_member(elem, "depth", file->depth);
+        json_object_set_int_member(elem, "inode", file->inode);
+        json_object_set_int_member(elem, "disk_id", file->dev);
+        json_object_set_boolean_member(elem, "is_original", file->is_original);
 
         if(file->lint_type == RM_LINT_TYPE_DUPE_DIR_CANDIDATE) {
-            rm_fmt_json_key_int(out, "n_children", file->n_children);
-            rm_fmt_json_sep(self, out);
+            json_object_set_int_member(elem, "n_children", file->n_children);
         }
 
         if(file->lint_type != RM_LINT_TYPE_UNIQUE_FILE) {
             if(file->twin_count >= 0) {
-                rm_fmt_json_key_int(out, "twins", file->twin_count);
-                rm_fmt_json_sep(self, out);
+                json_object_set_int_member(elem, "twins", file->twin_count);
             }
 
-
 			if(file->lint_type == RM_LINT_TYPE_PART_OF_DIRECTORY && file->parent_dir) {
-				rm_fmt_json_key_unsafe(out, "parent_path", rm_directory_get_dirname(file->parent_dir));
-				rm_fmt_json_sep(self, out);
-
+				json_object_set_string_member(elem, "parent_path", rm_directory_get_dirname(file->parent_dir));
 			}
 
             if(session->cfg->find_hardlinked_dupes) {
                 RmFile *hardlink_head = RM_FILE_HARDLINK_HEAD(file);
 
                 if(hardlink_head && hardlink_head != file && file->digest) {
-                    char orig_checksum_str[rm_digest_get_bytes(file->digest) * 2 + 1];
-                    rm_fmt_json_cksum(hardlink_head, orig_checksum_str,
-                                      sizeof(orig_checksum_str));
-
+                    char *orig_checksum_str = rm_fmt_json_cksum(hardlink_head);
                     RM_DEFINE_PATH(hardlink_head);
-
                     guint32 orig_id = rm_fmt_json_generate_id(
                         self, hardlink_head, hardlink_head_path, orig_checksum_str);
-
-                    rm_fmt_json_key_int(out, "hardlink_of", orig_id);
-                    rm_fmt_json_sep(self, out);
+                    g_free(orig_checksum_str);
+                    json_object_set_int_member(elem, "hardlink_of", orig_id);
                 }
             }
         }
 
-        rm_fmt_json_key_float(out, "mtime", file->mtime);
+        json_object_set_double_member(elem, "mtime", file->mtime);
     }
-    rm_fmt_json_close(self, out);
 
-    if(checksum_str != NULL) {
-        g_slice_free1(checksum_size, checksum_str);
-    }
+    json_array_add_object_element(self->array, elem);
+
+    g_free(checksum_str);
 }
 
 static RmFmtHandlerJSON JSON_HANDLER_IMPL = {
@@ -391,7 +271,7 @@ static RmFmtHandlerJSON JSON_HANDLER_IMPL = {
             .prog = NULL,
             .foot = rm_fmt_foot,
             .valid_keys = {"no_header", "no_footer", "no_body", "oneline", "unique", NULL},
-        },
-    .pretty = true};
+        }
+    };
 
 RmFmtHandler *JSON_HANDLER = (RmFmtHandler *)&JSON_HANDLER_IMPL;

--- a/lib/formats/json.c
+++ b/lib/formats/json.c
@@ -85,10 +85,11 @@ static void rm_fmt_json_open(RmSession *session, RmFmtHandlerJSON *self, FILE *o
     json_generator_set_pretty(
         self->generator, !rm_fmt_get_config_value(session->formats, "json", "oneline"));
 
-    json_generator_set_root(self->generator, json_node_alloc());
-    self->root = json_generator_get_root(self->generator);
+
     self->array = json_array_new();
+    self->root = json_node_alloc();
     json_node_init_array(self->root, self->array);
+    json_generator_set_root(self->generator, self->root);
 
     self->id_set = g_hash_table_new(NULL, NULL);
 }
@@ -100,6 +101,12 @@ static void rm_fmt_json_close(RmFmtHandlerJSON *self) {
     if(!json_generator_to_stream(self->generator, self->stream, false, &error)) {
         rm_log_error_line("Error writing to json stream");
     }
+
+    // free up memory
+    json_array_unref(self->array);
+    json_node_unref(self->root);
+    g_object_unref(self->generator);
+    g_object_unref(self->stream);
 
     g_hash_table_unref(self->id_set);
 }

--- a/lib/formats/json.c
+++ b/lib/formats/json.c
@@ -263,7 +263,7 @@ static void rm_fmt_elem(RmSession *session, _UNUSED RmFmtHandler *parent, FILE *
 
     if(file->lint_type == RM_LINT_TYPE_UNIQUE_FILE) {
         if(!rm_fmt_get_config_value(session->formats, "json", "unique")) {
-            if(!file->digest || !session->cfg->write_unfinished) {
+            if(!file->digest || !(session->cfg->write_unfinished || session->cfg->hash_uniques)) {
                 return;
             }
         }

--- a/lib/replay.c
+++ b/lib/replay.c
@@ -38,7 +38,6 @@
 #include <math.h>
 #include <string.h>
 
-#if HAVE_JSON_GLIB
 #include <json-glib/json-glib.h>
 
 typedef struct RmUnpackedDirectory {
@@ -961,22 +960,3 @@ void rm_parrot_cage_close(RmParrotCage *cage) {
     }
 }
 
-#else
-
-bool rm_parrot_cage_load(_UNUSED RmParrotCage *cage, _UNUSED const char *json_path,
-                         _UNUSED bool is_prefd) {
-    return false;
-}
-
-void rm_parrot_cage_open(_UNUSED RmParrotCage *cage, _UNUSED RmSession *session) {
-    rm_log_error_line(_("json-glib is needed for using --replay."));
-    rm_log_error_line(_("Please recompile `rmlint` with it installed."));
-}
-
-void rm_parrot_cage_flush(_UNUSED RmParrotCage *cage) {
-}
-
-void rm_parrot_cage_close(_UNUSED RmParrotCage *cage) {
-}
-
-#endif

--- a/lib/utilities.c
+++ b/lib/utilities.c
@@ -79,10 +79,6 @@
 #include <blkid/blkid.h>
 #endif
 
-#if HAVE_JSON_GLIB
-#include <json-glib/json-glib.h>
-#endif
-
 #define RM_MOUNTTABLE_IS_USABLE (HAVE_BLKID && HAVE_GIO_UNIX)
 
 ////////////////////////////////////

--- a/po/de.po
+++ b/po/de.po
@@ -301,10 +301,6 @@ msgid "Loading json-results `%s'"
 msgstr "Lade JSON Cache: `%s'"
 
 #: lib/replay.c
-msgid "json-glib is needed for using --replay."
-msgstr "json-glib wird zur Benutzung von `--replay` benötigt."
-
-#: lib/replay.c
 msgid "Please recompile `rmlint` with it installed."
 msgstr "Bitte kompilieren Sie `rmlint` entsprechend neu."
 
@@ -1032,10 +1028,6 @@ msgstr "Keine stamp Datei hier: `%s`. Es wird eine nach diesem Lauf erstellt."
 
 #~ msgid "%s%15"
 #~ msgstr "%s%15"
-
-#~ msgid "caching is not supported due to missing json-glib library."
-#~ msgstr ""
-#~ "Caching ist nicht möglich, da rmlint ohne json-glib kompiliert wurde."
 
 #~ msgid "Loading json-cache `%s'"
 #~ msgstr "Lade JSON Cache: `%s'"

--- a/po/es.po
+++ b/po/es.po
@@ -297,10 +297,6 @@ msgid "Loading json-results `%s'"
 msgstr "Cargando json-results '%s'"
 
 #: lib/replay.c
-msgid "json-glib is needed for using --replay."
-msgstr "json-glib es necesario para usar --replay."
-
-#: lib/replay.c
 msgid "Please recompile `rmlint` with it installed."
 msgstr "Por favor recompile 'rmlint' con ello instalado."
 
@@ -1004,10 +1000,6 @@ msgstr ""
 #, c-format
 msgid "No stamp file at `%s`, will create one after this run."
 msgstr ""
-
-#~ msgid "caching is not supported due to missing json-glib library."
-#~ msgstr ""
-#~ "el cacheo no es soportado debido a la librería inexistente json-glib"
 
 #~ msgid "Loading json-cache `%s'"
 #~ msgstr "Cargando json-cache '%s"

--- a/po/fr.po
+++ b/po/fr.po
@@ -295,10 +295,6 @@ msgid "Loading json-results `%s'"
 msgstr "Chargement de JSON Cache `%s'"
 
 #: lib/replay.c
-msgid "json-glib is needed for using --replay."
-msgstr "json-lib est nécessaire pour utiliser l'argument --replay"
-
-#: lib/replay.c
 msgid "Please recompile `rmlint` with it installed."
 msgstr "Merci de recompiler `rmlint` une fois celui ci installé"
 
@@ -1000,9 +996,6 @@ msgstr ""
 #, c-format
 msgid "No stamp file at `%s`, will create one after this run."
 msgstr ""
-
-#~ msgid "caching is not supported due to missing json-glib library."
-#~ msgstr "Cache non supporté, librairie json-glib manquante."
 
 #~ msgid "Loading json-cache `%s'"
 #~ msgstr "Chargement de JSON Cache `%s'"

--- a/src/rmlint.c
+++ b/src/rmlint.c
@@ -30,7 +30,7 @@
 #include "../lib/api.h"
 #include "../lib/config.h"
 
-#if HAVE_JSON_GLIB && !GLIB_CHECK_VERSION(2, 36, 0)
+#if !GLIB_CHECK_VERSION(2, 36, 0)
 #include <glib-object.h>
 #endif
 

--- a/tests/test_options/test_stdin.py
+++ b/tests/test_options/test_stdin.py
@@ -67,14 +67,15 @@ def test_path_starting_with_dash():
 
     try:
         os.chdir(TESTDIR_NAME)
-        data = check_output(
+        proc = subprocess.Popen(
             [cwd + '/rmlint', '-o', 'json', '-S', 'a', '--', subdir],
-            stderr=STDOUT
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE
         )
+        data, _ = proc.communicate("")
+        head, *data, footer = json.loads(data.decode('utf-8'))
     finally:
         os.chdir(cwd)
-
-    head, *data, footer = json.loads(data.decode('utf-8'))
 
     assert data[0]['path'].endswith('a')
     assert data[1]['path'].endswith('b')


### PR DESCRIPTION
Note this PR was branched off earlier PR https://github.com/sahib/rmlint/pull/479 to simplify possible merging.

Should address #464 and #463 and make json handling more robust in future.

One side-effect of this implementation is that the json file doesn't get written until right at the end.  The previous implementation writes to file as the results come in.

To do similar buffering with json-glib would require manually writing the opening and closing `[` and `]` to file, as well as the `,`'s between array elements, and using a new JsonGenerator for each element.  So it can be done but it's less elegant.  But if we we run into problems keeping the JsonArray in memory then we might have to go that way anyway.

Thoughts @sahib ?