### PR TITLE
--is-reflink and rm_util_link_type fixes

### DIFF
--- a/docs/rmlint.1.rst
+++ b/docs/rmlint.1.rst
@@ -821,18 +821,21 @@ OTHER STAND-ALONE COMMANDS
 
 
 :``rmlint --is-reflink [-v|-V] <file1> <file2>``:
-    Tests whether ``file1`` and ``file2`` are reflinks (reference same data).
-    This command makes ``rmlint`` exit with one of the following exit codes:
+    Tests whether ``file1`` and ``file2`` are reflinked (reference same data).
+    No attempt is made to resolve symlinks. You may want to preprocess
+    arguments with ``realpath(1)`` or equivalent to resolve symlinks and for
+    more reliable same-path detection.  This command makes ``rmlint`` exit with
+    one of the following exit codes:
 
-    * 0: Files are reflinks
+    * 0: Files are reflinked
     * 1: An error occurred during checking
     * 3: Not a regular file
     * 4: File sizes differ
     * 5: Files have inline extents
     * 6: Same file and path
     * 7: Same file but with different path
-    * 8: Hardlink
-    * 9: Symlink
+    * 8: Files are hardlinked
+    * 9: Encountered a symlink
     * 10: Files are on different devices
     * 11: Not linked
 

--- a/lib/utilities.c
+++ b/lib/utilities.c
@@ -1363,7 +1363,7 @@ RmLinkType rm_util_link_type(const char *path1, const char *path2, bool use_fiem
     }
 
     if(!S_ISREG(stat1.st_mode)) {
-        RM_RETURN(RM_LINK_NOT_FILE);
+        RM_RETURN(S_ISLNK(stat1.st_mode) ? RM_LINK_SYMLINK : RM_LINK_NOT_FILE);
     }
 
     int fd2 = rm_sys_open(path2, O_RDONLY);
@@ -1388,7 +1388,7 @@ RmLinkType rm_util_link_type(const char *path1, const char *path2, bool use_fiem
     }
 
     if(!S_ISREG(stat2.st_mode)) {
-        RM_RETURN(RM_LINK_NOT_FILE);
+        RM_RETURN(S_ISLNK(stat2.st_mode) ? RM_LINK_SYMLINK : RM_LINK_NOT_FILE);
     }
 
     if(stat1.st_size != stat2.st_size) {
@@ -1418,11 +1418,6 @@ RmLinkType rm_util_link_type(const char *path1, const char *path2, bool use_fiem
         if(!rm_util_same_device(path1, path2)) {
             RM_RETURN(RM_LINK_XDEV);
         }
-    }
-
-    /* If both are symbolic links we do not follow them */
-    if(S_ISLNK(stat1.st_mode) || S_ISLNK(stat2.st_mode)) {
-        RM_RETURN(RM_LINK_SYMLINK);
     }
 
     if(use_fiemap) {

--- a/lib/utilities.c
+++ b/lib/utilities.c
@@ -1433,13 +1433,13 @@ const char **rm_link_type_to_desc() {
     static const char *RM_LINK_TYPE_TO_DESC[] = {N_("Reflink"),
                                                  N_("An error occurred during checking"),
                                                  "Undefined",
-                                                 N_("Not a file"),
+                                                 N_("Not a regular file"),
                                                  N_("File sizes differ"),
                                                  N_("Files have inline extents"),
                                                  N_("Same file and path"),
                                                  N_("Same file but with different path"),
                                                  N_("Hardlink"),
-                                                 N_("Symlink"),
+                                                 N_("Encountered a symlink"),
                                                  N_("Files are on different devices"),
                                                  N_("Not linked")};
     return RM_LINK_TYPE_TO_DESC;

--- a/tests/test_mains/test_is_reflink.py
+++ b/tests/test_mains/test_is_reflink.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+import os
+import subprocess
+from contextlib import contextmanager
+from nose import with_setup
+from tests.utils import *
+
+
+@contextmanager
+def assert_exit_code(status_code):
+    """
+    Assert that the with block yields a subprocess.CalledProcessError
+    with a certain return code. If nothing is thrown, status_code
+    is required to be 0 to survive the test.
+    """
+    try:
+        yield
+    except subprocess.CalledProcessError as exc:
+        assert exc.returncode == status_code
+    else:
+        # No exception? status_code should be fine.
+        assert status_code == 0
+
+
+def check_is_reflink_status(status_code, *paths):
+    with assert_exit_code(status_code):
+        run_rmlint_once(
+            '--is-reflink', *paths,
+            use_default_dir=False,
+            with_json=False,
+            verbosity=''
+        )
+
+
+@with_setup(usual_setup_func, usual_teardown_func)
+def test_bad_arguments():
+    path_a = create_file('xxx', 'a')
+    path_b = create_file('xxx', 'b')
+    path_c = create_file('xxx', 'c')
+    for paths in [
+        (path_a,),
+        (path_a, path_b, path_c),
+        (path_a, path_a + '.nonexistent')
+    ]:
+        check_is_reflink_status(1, *paths)
+
+
+@with_setup(usual_setup_func, usual_teardown_func)
+def test_directories():
+    path_a = create_dirs('dir_a')
+    path_b = create_dirs('dir_b')
+    check_is_reflink_status(3, path_a, path_b)
+
+
+@with_setup(usual_setup_func, usual_teardown_func)
+def test_different_sizes():
+    path_a = create_file('xxx', 'a')
+    path_b = create_file('xxxx', 'b')
+    check_is_reflink_status(4, path_a, path_b)
+
+
+@with_setup(usual_setup_func, usual_teardown_func)
+def test_same_path():
+    path_a = create_file('xxx', 'a')
+    check_is_reflink_status(6, path_a, path_a)
+
+
+@with_setup(usual_setup_func, usual_teardown_func)
+def test_path_double():
+    path_a = create_file('xxx', 'dir/a')
+    create_link('dir', 'dir_symlink', symlink=True)
+    path_b = os.path.join(TESTDIR_NAME, 'dir_symlink/a')
+    check_is_reflink_status(7, path_a, path_b)
+
+
+@with_setup(usual_setup_func, usual_teardown_func)
+def test_hardlinks():
+    path_a = create_file('xxx', 'a')
+    path_b = path_a + '_hardlink'
+    create_link('a', 'a_hardlink', symlink=False)
+    check_is_reflink_status(8, path_a, path_b)
+
+
+@with_setup(usual_setup_func, usual_teardown_func)
+def test_symlink():
+    path_a = create_file('xxx', 'a')
+    path_b = create_file('xxx', 'b') + '_symlink'
+    create_link('b', 'b_symlink', symlink=True)
+    check_is_reflink_status(9, path_a, path_b)


### PR DESCRIPTION
The most important change here is to allow rm_util_link_type to return RM_LINK_SYMLINK by checking for it earlier.

```
$ touch foo.txt bar.txt
$ ln -s bar.txt link.txt
$ rmlint --is-reflink foo.txt link.txt
```

Result before these changes: `Not a file` (exit status 3)
Result after these changes: `Encountered a symlink` (exit status 9)