### PR TITLE
Fix verbosity logic and documentation

### DIFF
--- a/docs/rmlint.1.rst
+++ b/docs/rmlint.1.rst
@@ -200,14 +200,14 @@ General Options
 
     Increase or decrease the verbosity. You can pass these options several
     times. This only affects ``rmlint``'s logging on *stderr*, but not the
-    outputs defined with **-o**. Passing either option more than three times
-    has no further effect.
+    outputs defined with **-o**. Passing either option more than twice has no
+    further effect.
 
 :``-g --progress`` / ``-G --no-progress`` (**default**):
 
     Show a progressbar with sane defaults.
 
-    Convenience shortcut for ``-o progressbar -o summary -o sh:rmlint.sh -o json:rmlint.json -VVV``.
+    Convenience shortcut for ``-o progressbar -o summary -o sh:rmlint.sh -o json:rmlint.json -VV``.
 
     NOTE: This flag clears all previous outputs. If you want additional
     outputs, specify them after this flag using ``-O``.
@@ -816,8 +816,8 @@ OTHER STAND-ALONE COMMANDS
     * -r, --readonly           Even dedupe read-only [btrfs] snapshots (needs root)
     * -f, --followlinks        Follow symlinks
     * -i, --inline-extents     Try to dedupe files with inline extents
-    * -v, --loud               Be more verbose (-vvv for much more)
-    * -V, --quiet              Be less verbose (-VVV for much less)
+    * -v, --loud               Be more verbose (-vv for much more)
+    * -V, --quiet              Be less verbose (-VV for much less)
 
 
 :``rmlint --is-reflink [-v|-V] <file1> <file2>``:
@@ -995,8 +995,8 @@ Please make sure to describe your problem in detail. Always include the version
 of ``rmlint`` (``--version``). If you experienced a crash, please include
 at least one of the following information with a debug build of ``rmlint``:
 
-* ``gdb --ex run -ex bt --args rmlint -vvv [your_options]``
-* ``valgrind --leak-check=no rmlint -vvv [your_options]``
+* ``gdb --ex run -ex bt --args rmlint -vv [your_options]``
+* ``valgrind --leak-check=no rmlint -vv [your_options]``
 
 You can build a debug build of ``rmlint`` like this:
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -827,7 +827,7 @@ Here's just a list of options that are nice to know, but are not essential:
   But you would have checked the output anyways, wouldn't you?
 
 - If something ever goes wrong, it might help to increase the verbosity with
-  ``-v`` (up to ``-vvv``).
+  ``-v`` (up to ``-vv``).
 - Usually the commandline output is colored, but you can disable it explicitly
   with ``-w`` (``--with-color``). If *stdout* or *stderr* is not a terminal
   anyways, ``rmlint`` will disable colors itself.

--- a/lib/cmdline.c
+++ b/lib/cmdline.c
@@ -1125,11 +1125,11 @@ bool rm_cmd_parse_args(int argc, char **argv, RmSession *session) {
         {"xattr"            , 'C' , EMPTY    , G_OPTION_ARG_CALLBACK , FUNC(xattr)          , _("Enable xattr based caching")           , ""}                        ,
 
         /* Non-trivial switches */
-        {"progress" , 'g' , EMPTY , G_OPTION_ARG_CALLBACK , FUNC(progress)    , _("Enable progressbar")                   , NULL} ,
-        {"loud"     , 'v' , EMPTY , G_OPTION_ARG_CALLBACK , rm_logger_louder  , _("Be more verbose (-vvv for much more)") , NULL} ,
-        {"quiet"    , 'V' , EMPTY , G_OPTION_ARG_CALLBACK , rm_logger_quieter , _("Be less verbose (-VVV for much less)") , NULL} ,
-        {"replay"   , 'Y' , 0     , G_OPTION_ARG_CALLBACK , FUNC(replay)      , _("Re-output a json file")                , "path/to/rmlint.json"} ,
-        {"equal"    ,  0 ,  EMPTY , G_OPTION_ARG_CALLBACK , FUNC(equal)       , _("Test for equality of PATHS")           , "PATHS"}           ,
+        {"progress" , 'g' , EMPTY , G_OPTION_ARG_CALLBACK , FUNC(progress)    , _("Enable progressbar")                  , NULL} ,
+        {"loud"     , 'v' , EMPTY , G_OPTION_ARG_CALLBACK , rm_logger_louder  , _("Be more verbose (-vv for much more)") , NULL} ,
+        {"quiet"    , 'V' , EMPTY , G_OPTION_ARG_CALLBACK , rm_logger_quieter , _("Be less verbose (-VV for much less)") , NULL} ,
+        {"replay"   , 'Y' , 0     , G_OPTION_ARG_CALLBACK , FUNC(replay)      , _("Re-output a json file")               , "path/to/rmlint.json"} ,
+        {"equal"    ,  0 ,  EMPTY , G_OPTION_ARG_CALLBACK , FUNC(equal)       , _("Test for equality of PATHS")          , "PATHS"}           ,
 
         /* Trivial boolean options */
         {"no-with-color"            , 'W'  , DISABLE   , G_OPTION_ARG_NONE      , &cfg->with_color               , _("Be not that colorful")                                                 , NULL}     ,

--- a/lib/logger.c
+++ b/lib/logger.c
@@ -31,10 +31,10 @@
 static gboolean with_stderr_color = TRUE;
 
 static GLogLevelFlags VERBOSITY_TO_LOG_LEVEL[] = {
-    [0] = G_LOG_LEVEL_CRITICAL,
-    [1] = G_LOG_LEVEL_ERROR,
+    [0] = G_LOG_LEVEL_ERROR,
+    [1] = G_LOG_LEVEL_CRITICAL,
     [2] = G_LOG_LEVEL_WARNING,
-    [3] = G_LOG_LEVEL_MESSAGE | G_LOG_LEVEL_INFO,
+    [3] = G_LOG_LEVEL_INFO,
     [4] = G_LOG_LEVEL_DEBUG};
 
 static gint verbosity = 2;
@@ -72,7 +72,7 @@ void rm_logger_set_verbosity(const gint new_verbosity) {
     verbosity = new_verbosity;
     min_log_level = VERBOSITY_TO_LOG_LEVEL[CLAMP(
         verbosity,
-        1,
+        0,
         (int)(sizeof(VERBOSITY_TO_LOG_LEVEL) / sizeof(GLogLevelFlags)) - 1)];
 }
 

--- a/lib/reflink.c
+++ b/lib/reflink.c
@@ -195,8 +195,8 @@ int rm_dedupe_main(int argc, const char **argv) {
         {"followlinks"   , 'f' , 0                     , G_OPTION_ARG_NONE     , &follow_symlinks   , _("Follow symlinks")                                                      , NULL},
         {"inline-extents", 'i' , G_OPTION_FLAG_REVERSE , G_OPTION_ARG_NONE     , &follow_symlinks   , _("Try to dedupe files with inline extents")                              , NULL},
         {"without-fiemap", 'w' , G_OPTION_FLAG_REVERSE , G_OPTION_ARG_NONE     , &use_fiemap        , _("Don't use fiemap to check whether files are already reflinked")        , NULL},
-        {"loud"          , 'v' , G_OPTION_FLAG_NO_ARG  , G_OPTION_ARG_CALLBACK , rm_logger_louder   , _("Be more verbose (-vvv for much more)")                                 , NULL},
-        {"quiet"         , 'V' , G_OPTION_FLAG_NO_ARG  , G_OPTION_ARG_CALLBACK , rm_logger_quieter  , _("Be less verbose (-VVV for much less)")                                 , NULL},
+        {"loud"          , 'v' , G_OPTION_FLAG_NO_ARG  , G_OPTION_ARG_CALLBACK , rm_logger_louder   , _("Be more verbose (-vv for much more)")                                  , NULL},
+        {"quiet"         , 'V' , G_OPTION_FLAG_NO_ARG  , G_OPTION_ARG_CALLBACK , rm_logger_quieter  , _("Be less verbose (-VV for much less)")                                  , NULL},
         {NULL            , 0   , 0                     , 0                     , NULL               , NULL                                                                      , NULL}};
 
 
@@ -448,8 +448,8 @@ int rm_dedupe_main(int argc, const char **argv) {
 int rm_is_reflink_main(int argc, const char **argv) {
 
     const GOptionEntry options[] = {
-        {"loud"          , 'v' , G_OPTION_FLAG_NO_ARG  , G_OPTION_ARG_CALLBACK , rm_logger_louder   , _("Be more verbose (-vvv for much more)")                                 , NULL},
-        {"quiet"         , 'V' , G_OPTION_FLAG_NO_ARG  , G_OPTION_ARG_CALLBACK , rm_logger_quieter  , _("Be less verbose (-VVV for much less)")                                 , NULL},
+        {"loud"          , 'v' , G_OPTION_FLAG_NO_ARG  , G_OPTION_ARG_CALLBACK , rm_logger_louder   , _("Be more verbose (-vv for much more)")                                  , NULL},
+        {"quiet"         , 'V' , G_OPTION_FLAG_NO_ARG  , G_OPTION_ARG_CALLBACK , rm_logger_quieter  , _("Be less verbose (-VV for much less)")                                  , NULL},
         {NULL            , 0   , 0                     , 0                     , NULL               , NULL                                                                      , NULL}};
 
 

--- a/po/de.po
+++ b/po/de.po
@@ -671,12 +671,12 @@ msgid "Enable progressbar"
 msgstr "Zeige Fortschrittsbalken"
 
 #: lib/cmdline.c
-msgid "Be more verbose (-vvv for much more)"
-msgstr "Sei gesprächiger (-vvv für Quasselstrippe)"
+msgid "Be more verbose (-vv for much more)"
+msgstr "Sei gesprächiger (-vv für Quasselstrippe)"
 
 #: lib/cmdline.c
-msgid "Be less verbose (-VVV for much less)"
-msgstr "Sei weniger gesprächig (-VVV für Totenstille)"
+msgid "Be less verbose (-VV for much less)"
+msgstr "Sei weniger gesprächig (-VV für Totenstille)"
 
 #: lib/cmdline.c
 msgid "Re-output a json file"

--- a/po/es.po
+++ b/po/es.po
@@ -656,12 +656,12 @@ msgid "Enable progressbar"
 msgstr "Habilitar la barra de progreso"
 
 #: lib/cmdline.c
-msgid "Be more verbose (-vvv for much more)"
-msgstr "Sé más explicativo (-vvv para mucho más)"
+msgid "Be more verbose (-vv for much more)"
+msgstr "Sé más explicativo (-vv para mucho más)"
 
 #: lib/cmdline.c
-msgid "Be less verbose (-VVV for much less)"
-msgstr "Sé menos explicativo (-VVV para mucho menos)"
+msgid "Be less verbose (-VV for much less)"
+msgstr "Sé menos explicativo (-VV para mucho menos)"
 
 #: lib/cmdline.c
 msgid "Re-output a json file"

--- a/po/fr.po
+++ b/po/fr.po
@@ -650,12 +650,12 @@ msgid "Enable progressbar"
 msgstr "Activer la barre de progression"
 
 #: lib/cmdline.c
-msgid "Be more verbose (-vvv for much more)"
-msgstr "Être plus verbeux (-vvv pour l'être encore plus)"
+msgid "Be more verbose (-vv for much more)"
+msgstr "Être plus verbeux (-vv pour l'être encore plus)"
 
 #: lib/cmdline.c
-msgid "Be less verbose (-VVV for much less)"
-msgstr "Être moins verbeux (-VVV pour l'être encore moins)"
+msgid "Be less verbose (-VV for much less)"
+msgstr "Être moins verbeux (-VV pour l'être encore moins)"
 
 #: lib/cmdline.c
 msgid "Re-output a json file"

--- a/po/rmlint.pot
+++ b/po/rmlint.pot
@@ -638,11 +638,11 @@ msgid "Enable progressbar"
 msgstr ""
 
 #: lib/cmdline.c
-msgid "Be more verbose (-vvv for much more)"
+msgid "Be more verbose (-vv for much more)"
 msgstr ""
 
 #: lib/cmdline.c
-msgid "Be less verbose (-VVV for much less)"
+msgid "Be less verbose (-VV for much less)"
 msgstr ""
 
 #: lib/cmdline.c

--- a/tests/test_formatters/test_others.py
+++ b/tests/test_formatters/test_others.py
@@ -25,7 +25,7 @@ def test_just_call_it():
 
     for silly_option in ['-ppp', '-PPPP']:
         try:
-            subprocess.check_output(['./rmlint', '-VVV', silly_option, TESTDIR_NAME])
+            subprocess.check_output(['./rmlint', '-VV', silly_option, TESTDIR_NAME])
         except subprocess.CalledProcessError:
             pass
         else:


### PR DESCRIPTION
Only five verbosity levels really exist (`-VV` through `-vv`), and `-VV` couldn't even be reached before - but that was masked by the first two (G_LOG_LEVEL_ERROR and G_LOG_LEVEL_CRITICAL) being the wrong way around.

This will only break scripts if they relied on `-V` silencing errors logged to stderr, but if scripts were silencing stderr they were most likely ignoring it, and this was an undocumented "feature" (the docs recommended `-VVV`), so IMO it's not a concern.

#### Example 1
```
$ rmlint --is-reflink nothing nothing
```

Output before and after these changes:
```
ERROR: lib/utilities.c:1335: rm_util_link_type: Error opening nothing: No such file or directory
An error occurred during checking
```

#### Example 2
```
$ rmlint --is-reflink -V nothing nothing
```

Output before these changes:
(no output)
The warning _and_ the error have been disabled, because `G_LOG_LEVEL_ERROR >= G_LOG_LEVEL_CRITICAL` is false. This is the lowest verbosity level; `-VV` and `-VVV` are clamped to `-V`.

Output after these changes:
```
ERROR: lib/utilities.c:1335: rm_util_link_type: Error opening nothing: No such file or directory
```
The warning has been disabled.

#### Example 3
```
$ rmlint --is-reflink -VV nothing nothing
```

Output before and after these changes:
(no output)
The warning and the error have been disabled. This worked before by coincidence, as it was effectively `-V` but `-V` silenced errors too.