### PR TITLE
Fix small typo on the manpage

### DIFF
--- a/docs/rmlint.1.rst
+++ b/docs/rmlint.1.rst
@@ -967,7 +967,7 @@ PROBLEMS
 SEE ALSO
 ========
 
-Reading the manpages o these tools might help working with ``rmlint``:
+Reading the manpages of these tools might help working with ``rmlint``:
 
 * `find(1)`
 * `rm(1)`


### PR DESCRIPTION
Replace "Reading the manpages o these tools" by "Reading the manpages o**f** these tools"