### PR TITLE
Build: allow disabling docs, do not build gschemas.compiled

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -515,7 +515,7 @@ AddOption(
     action='store', metavar='DIR', help='libdir name (lib or lib64)'
 )
 
-for suffix in ['libelf', 'gettext', 'fiemap', 'blkid', 'json-glib', 'gui']:
+for suffix in ['libelf', 'gettext', 'fiemap', 'blkid', 'json-glib', 'gui', 'docs']:
     AddOption(
         '--without-' + suffix, action='store_const', default=False, const=False,
         dest='with_' + suffix
@@ -804,7 +804,8 @@ env.Default(library)
 
 SConscript('tests/SConscript', exports='programs')
 SConscript('po/SConscript')
-SConscript('docs/SConscript')
+if GetOption("with_docs"):
+    SConscript('docs/SConscript')
 SConscript('gui/SConscript')
 
 
@@ -898,6 +899,9 @@ if 'config' in COMMAND_LINE_TARGETS:
         (needs <locale.h> for compile side support)       : {locale}
         (needs msgfmt to compile .po files)               : {msgfmt}
 
+    Enable GUI                                            : {gui}
+    Build docs                                            : {docs}
+
 {grey}The following constants will be used during the build:{end}
 
     Version information  : {version}
@@ -925,6 +929,8 @@ Type 'scons' to actually compile rmlint now. Good luck.
             bigfiles=yesno(env['HAVE_BIGFILES']),
             bigofft=yesno(env['HAVE_BIG_OFF_T']),
             bigstat=yesno(env['HAVE_BIG_STAT']),
+            gui=yesno(GetOption("with_gui")),
+            docs=yesno(GetOption("with_docs")),
             sphinx=COLORS['green'] + 'yes, using ' + COLORS['end'] + sphinx_bin if sphinx_bin else yesno(sphinx_bin),
             compiler=env['CC'],
             prefix=GetOption('prefix'),

--- a/gui/setup.py
+++ b/gui/setup.py
@@ -37,7 +37,7 @@ def get_prefix():
 PREFIX = get_prefix()
 
 
-class PrePlusPostInstall(install):
+class PreInstall(install):
     def run(self):
         # Compile the resource bundle freshly
         print('==> Compiling resource bundle')
@@ -59,24 +59,6 @@ class PrePlusPostInstall(install):
         # Run the usual distutils install routine:
         install.run(self)
 
-        # Make sure the schema file is updated.
-        # Otherwise the gui will trace trap.
-        print('==> Compiling GLib Schema files')
-
-        try:
-            subprocess.call([
-                'glib-compile-schemas',
-                os.path.join(PREFIX, 'share/glib-2.0/schemas')
-            ])
-        except subprocess.CalledProcessError as err:
-            print('==> Could not update schemas: ', err)
-            print('==> Please run the following manually:\n')
-            print('    sudo glib-compile-schemas {prefix}'.format(
-                prefix=os.path.join(PREFIX, 'share/glib-2.0/schemas')
-            ))
-        else:
-            print('==> OK!')
-
 
 setup(
     name='Shredder',
@@ -88,7 +70,7 @@ setup(
     url='https://rmlint.rtfd.org',
     license='GPLv3',
     platforms='any',
-    cmdclass={'install': PrePlusPostInstall},
+    cmdclass={'install': PreInstall},
     packages=['shredder', 'shredder.views'],
     package_data={'': [
         'resources/*.gresource'


### PR DESCRIPTION
Hi,
I am in the process of adding rmlint to Gentoo and I have a few problems, some of which I patched locally. However, I think these two should be fixed upstream.

* allow disabling docs
* do not build `gschemas.compiled`. Having this file installed causes problems for packagers. Fedora and    Arch Linux have to remove it manually as we can see here:
https://github.com/sahib/rmlint/blob/29bd07e29edf6879be933dc0e7275a90a154c00e/pkg/fedora/rmlint.spec#L48
https://github.com/archlinux/svntogit-community/blob/19a815339b610b3ee146d7e3830f3c8ac3a2a6c4/trunk/PKGBUILD#L44
