### PR TITLE
Do not compress manpage

### DIFF
--- a/docs/SConscript
+++ b/docs/SConscript
@@ -31,18 +31,6 @@ def run_sphinx_binary(builder, **kwargs):
         [sphinx_binary, '-Q', '-b', builder, 'docs', build_dir]
     )
 
-
-def gzip_file(target, source, env):
-    source, dest = source[0].get_abspath(), target[0].get_abspath()
-    try:
-        subprocess.check_call('gzip -c {s} > {t}'.format(
-            s=source, t=dest
-        ), shell=True)
-    except Exception as err:
-        print('Warning: could not gzip {s} to {t}: {e}'.format(
-            s=source, t=dest, e=err
-        ))
-
 # Do not use partial(), but a real function.
 # Scons uses this to check if the previous action
 # differs from the current action.
@@ -51,19 +39,14 @@ def run_sphinx_binary_man(**kwargs):
     run_sphinx_binary('man', **kwargs)
 
 
-sphinx = env.Command(
+manpage = env.Command(
     '_build/man/rmlint.1', 'rmlint.1.rst',
     env.Action(run_sphinx_binary_man, "Building manpage from rst...")
 )
 
-manpage = env.Command(
-    'rmlint.1.gz', '_build/man/rmlint.1', gzip_file
-)
-
-env.Default(sphinx)
 env.Default(manpage)
 
-env.Alias('man', env.Depends(manpage, sphinx))
+env.Alias('man', manpage)
 
 
 if 'install' in COMMAND_LINE_TARGETS:

--- a/lib/cmdline.c
+++ b/lib/cmdline.c
@@ -97,7 +97,7 @@ static void rm_cmd_show_version(void) {
 }
 
 static void rm_cmd_show_manpage(void) {
-    static const char *commands[] = {"man %s docs/rmlint.1.gz 2> /dev/null",
+    static const char *commands[] = {"man %s docs/_build/man/rmlint.1 2> /dev/null",
                                      "man %s rmlint", NULL};
 
     bool found_manpage = false;


### PR DESCRIPTION
Hi,
Pre-compressing the manpage causes QA warnings on Gentoo (and could also be a problem on Debian, Fedora or Arch Linux, as a fellow Gentoo developer explains [in his blog](https://cmpct.info/~sam/blog/posts/automatic-manpage-compression/)).

It would be nice to disable this feature.