### PR TITLE
Never hardcode compiler, select it based on CC environment variable

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -37,8 +37,9 @@ Export('VERSION_MAJOR VERSION_MINOR VERSION_PATCH VERSION_NAME')
 def check_gcc_version(context):
     context.Message('Checking for GCC version... ')
 
+    gcc = os.environ.get("CC", "gcc")
     try:
-        v = subprocess.check_output("printf '%s\n' __GNUC__ | gcc -E -P -", shell=True)
+        v = subprocess.check_output("printf '%s\n' __GNUC__ | {} -E -P -".format(gcc), shell=True)
         try:
             v = int(v)
             context.Result(str(v))

--- a/tests/test_types/test_nonstripped.py
+++ b/tests/test_types/test_nonstripped.py
@@ -21,8 +21,12 @@ def create_binary(path, stripped=False):
     path = path + '.stripped' if stripped else path + '.nonstripped'
     full_path = os.path.join(TESTDIR_NAME, path)
 
-    command = 'echo \'{src}\' | cc -o {path} {option} -std=c99 -xc -'.format(
-        src=SOURCE, path=full_path, option=('-s' if stripped else '-ggdb3')
+    cc = os.environ.get("CC", "cc")
+    command = 'echo \'{src}\' | {cc} -o {path} {option} -std=c99 -xc -'.format(
+        cc=cc,
+        src=SOURCE,
+        path=full_path,
+        option=('-s' if stripped else '-ggdb3')
     )
     subprocess.call(command, shell=True)
 


### PR DESCRIPTION
This avoids problems where `gcc`/`cc` is not the prefered compiler.