### PR TITLE
(Docs) Fix semantic typo

### DIFF
--- a/docs/rmlint.1.rst
+++ b/docs/rmlint.1.rst
@@ -807,7 +807,7 @@ OTHER STAND-ALONE COMMANDS
 
     This command is similar to ``cp --reflink=always <src> <dest>``
     except that it (a) checks that ``src`` and ``dest`` have identical data, and
-    it makes no changes to ``dest``'s metadata.
+    (b) it makes no changes to ``dest``'s metadata.
 
     Running with ``-r`` option will enable deduplication of read-only [btrfs]
     snapshots (requires root).


### PR DESCRIPTION
The documentation text begins a list with `(a)` but doesn't reference the second item with `(b)`.
This PR fixes this "semantic" typo.