### PR TITLE
SConscript: fix copy-paste error

### DIFF
--- a/lib/SConscript
+++ b/lib/SConscript
@@ -112,7 +112,7 @@ if not env['HAVE_SSE4_1']:
 
 if not env['HAVE_SSE2']:
 	print('Not compiling blake3 sse2 options')
-	blake3 = [f for f in blake3 if 'sse41' not in f.path]
+	blake3 = [f for f in blake3 if 'sse2' not in f.path]
 	env.Append(CCFLAGS=['-DBLAKE3_NO_SSE2'])
 
 library = env.Library(


### PR DESCRIPTION
This was causing issues on platforms that don't support SSE2, such as ARM.

Fixes #547