### PR TITLE
fix undefined macros

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -773,6 +773,9 @@ if conf.env['HAVE_SSE4_1']:
 if conf.env['HAVE_SSE2']:
 	conf.env.Append(CCFLAGS=['-msse2'])
 
+# NB: After checks so they don't fail
+conf.env.Append(CCFLAGS=['-Werror=undef'])
+
 
 if ARGUMENTS.get('GDB') == '1':
     ARGUMENTS['DEBUG'] = '1'

--- a/lib/config.h.in
+++ b/lib/config.h.in
@@ -57,17 +57,20 @@
 #define LLI G_GINT64_FORMAT
 
 
+#include <stdint.h> /* for UINTPTR_MAX */
 #define RM_PLATFORM_32 (UINTPTR_MAX == 0xffffffff)
 #define RM_PLATFORM_64 (UINTPTR_MAX == 0xffffffffffffffff)
 
-#ifdef __APPLE__
-# ifdef __MACH__
-#  define RM_IS_APPLE 1
-# endif
+#if defined(__APPLE__) && defined(__MACH__)
+# define RM_IS_APPLE 1
+#else
+# define RM_IS_APPLE 0
 #endif
 
 #ifdef __CYGWIN__
 # define RM_IS_CYGWIN 1
+#else
+# define RM_IS_CYGWIN 0
 #endif
 
 #include <glib.h>
@@ -118,5 +121,7 @@ typedef guint64 RmOff;
     /* give up */
     #define WARN_UNUSED_RESULT
 #endif
+
+#define _RM_OFFSET_DEBUG 0
 
 #endif

--- a/lib/hasher.c
+++ b/lib/hasher.c
@@ -31,20 +31,23 @@
 
 #include "utilities.h"
 
+#ifndef POSIX_FADV_SEQUENTIAL
+# define POSIX_FADV_SEQUENTIAL 0
+#endif
+#ifndef POSIX_FADV_WILLNEED
+# define POSIX_FADV_WILLNEED 0
+#endif
+#ifndef POSIX_FADV_NOREUSE
+# define POSIX_FADV_NOREUSE 0
+#endif
+
 /* Flags for the fadvise() call that tells the kernel
  * what we want to do with the file.
  */
-const int HASHER_FADVISE_FLAGS = 0
-#ifdef POSIX_FADV_SEQUENTIAL
-                                 | POSIX_FADV_SEQUENTIAL /* Read from 0 to file-size    */
-#endif
-#ifdef POSIX_FADV_WILLNEED
-                                 | POSIX_FADV_WILLNEED /* Tell the kernel to readahead */
-#endif
-#ifdef POSIX_FADV_NOREUSE
-                                 | POSIX_FADV_NOREUSE /* We will not reuse old data  */
-#endif
-    ;
+#define HASHER_FADVISE_FLAGS 0                                 \
+    | POSIX_FADV_SEQUENTIAL /* Read from 0 to file-size     */ \
+    | POSIX_FADV_WILLNEED   /* Tell the kernel to readahead */ \
+    | POSIX_FADV_NOREUSE    /* We will not reuse old data   */
 
 #define DIVIDE_CEIL(n, m) ((n) / (m) + !!((n) % (m)))
 

--- a/lib/md-scheduler.c
+++ b/lib/md-scheduler.c
@@ -27,6 +27,8 @@
 #include "md-scheduler.h"
 
 
+#define _RM_MDS_DEBUG 0
+
 /* How many milliseconds to sleep if we encounter an empty file queue.
  * This prevents a "starving" RmShredDevice from hogging cpu and cluttering up
  * debug messages by continually recycling back to the joiner.

--- a/lib/traverse.c
+++ b/lib/traverse.c
@@ -246,6 +246,8 @@ static void rm_traverse_convert_small_stat_buf(struct stat *fts_statp, RmStat *b
 
 #else
 
+G_STATIC_ASSERT(G_SIZEOF_MEMBER(RmStat, st_size) == G_SIZEOF_MEMBER(__fts_stat_t, st_size));
+
 #define ADD_FILE(lint_type, is_symlink) \
     _ADD_FILE(lint_type, is_symlink, (RmStat *)p->fts_statp)
 

--- a/lib/utilities.c
+++ b/lib/utilities.c
@@ -1154,8 +1154,6 @@ bool rm_mounts_can_reflink(RmMountTable *self, dev_t source, dev_t dest) {
 
 #if HAVE_FIEMAP
 
-#define _RM_OFFSET_DEBUG 0
-
 /* Return fiemap structure containing n_extents for file descriptor fd.
  * Return NULL if errors encountered.
  * Needs to be freed with g_free if not NULL.


### PR DESCRIPTION
The worst of them were an undefined UINTPTR_MAX in RM_PLATFORM_*, which could both be false and caused a stat struct to be mis-casted in traverse.c, and a non-macro HASHER_FADVISE_FLAGS that made rm_hasher_request_readahead a no-op since commit 31cd32f1.

Also add a static assert in the usual ADD_FILE to make sure it never casts between incompatible stat structs, and -Werror=undef so we don't allow undefined macros to silently evaluate to zero.

The UINTPTR_MAX issue is a regression caused by 90edf021, which removed the inttypes.h include in config.h.in.

Fixes #549

---

Here's the preprocessor condition that wasn't working:
https://github.com/sahib/rmlint/blob/bdb591f4bc124fad6da1035ffb2b513826e9d64f/lib/traverse.c#L215

Here's the definition of RM_PLATFORM_32:
https://github.com/sahib/rmlint/blob/bdb591f4bc124fad6da1035ffb2b513826e9d64f/lib/config.h.in#L60

stdint.h was not being included in either config.h or traverse.c, so UINTPTR_MAX was undefined and (by default) silently evaluates to zero. Note that this PR brings back rm_hasher_request_readahead for the first time in over 6 years, which I haven't thoroughly tested (but is most likely fine).