### PR TITLE
utilities: Prevent deadlock in rm_util_is_nonstripped

### DIFF
--- a/lib/utilities.c
+++ b/lib/utilities.c
@@ -296,7 +296,7 @@ bool rm_util_is_nonstripped(_UNUSED const char *path, _UNUSED RmStat *statp) {
 #if HAVE_LIBELF
     g_return_val_if_fail(path, false);
 
-    if(statp && (statp->st_mode & (S_IXUSR | S_IXGRP | S_IXOTH)) == 0) {
+    if(!S_ISREG(statp->st_mode) || (statp->st_mode & (S_IXUSR | S_IXGRP | S_IXOTH)) == 0) {
         return false;
     }
 


### PR DESCRIPTION
Only attempt to open regular files. It is entirely possible that we
encounter an executable FIFO, which causes open() to block indefinitely
if it is not opened for writing by another process.

Fixes #555