### PR TITLE
Update maintainance on README to 2022. (previous: only 2017, then none)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,7 @@ Here's a list of developers to blame:
 
 ===================================  ============================= ===========================================
 *Christopher Pahl*                   https://github.com/sahib      2010-2017
-*Daniel Thomas*                      https://github.com/SeeSpotRun 2014-2017
+*Daniel Thomas*                      https://github.com/SeeSpotRun 2014-2021
 ===================================  ============================= ===========================================
 
 There are some other people that helped us of course.


### PR DESCRIPTION
The README page was showing maintenance from SeeSpotRun only in the range 2014-*2017*.

Leaving therefore the impression, at first glance, that this project does not have a maintainer since 2017, which apparently is not the case 
(inner .hpp files which showed dates such as 2020, etc.).

Updated maintained year to current year, 2022, so that, since the README is the first glance of a project to prospecting new users, the project will appear as currently maintained, which seems to be well the case.