### PR TITLE
Fixed manpage typo in rmlint jq pipe example

### DIFF
--- a/docs/rmlint.1.rst
+++ b/docs/rmlint.1.rst
@@ -701,7 +701,7 @@ FORMATTERS
   that is not directly possible with rmlint's built-in options. A very handy tool here is ``jq``.
   Here is an example to output all original files directly from a ``rmlint`` run:
 
-  ``$ rmlint -o | json jq -r '.[1:-1][] | select(.is_original) | .path'``
+  ``$ rmlint -o json | jq -r '.[1:-1][] | select(.is_original) | .path'``
 
 * ``py``: Outputs a python script and a JSON document, just like the **json** formatter.
   The JSON document is written to ``.rmlint.json``, executing the script will


### PR DESCRIPTION
There is a simple typo I noticed in the manpage in the scripting example. The pipe is in the wrong place for the command to work.

(This is my first actual PR, please be gentle if I've made some kind of mistake!)