### PR TITLE
tests: fix "DeprecationWarning: invalid escape sequence"

### DIFF
--- a/tests/test_options/test_size.py
+++ b/tests/test_options/test_size.py
@@ -61,7 +61,7 @@ def test_invalid():
             assert False
 
     # Not a valid range:
-    trigger('--size \-\-17')
+    trigger(r'--size --17')
 
     # max < min
     trigger('--size 10-9')


### PR DESCRIPTION
Before this fix, we would see
```
DeprecationWarning: invalid escape sequence '\-'
```