### PR TITLE
Tests: replace nose with pytest

### DIFF
--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -237,13 +237,13 @@ Notable targets
 
 :test:
 
-    Build the tests (requires ``python`` and ``nosetest`` installed).
-    Optionally ``valgrind`` can be installed to run the tests through 
+    Build the tests (requires ``python`` and ``pytest`` installed).
+    Optionally ``valgrind`` can be installed to run the tests through
     valgrind:
 
     .. code-block:: bash
 
-        $ USE_VALGRIND=1 nosetests  # or nosetests-3.3, python3 needed.
+        $ USE_VALGRIND=1 pytest
 
 :xgettext:
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -97,7 +97,7 @@ Here's a list of readily prepared commands for known operating systems:
 
   .. code-block:: bash
 
-    $ apt-get install pkg-config git scons python3-sphinx python3-nose gettext build-essential
+    $ apt-get install pkg-config git scons python3-sphinx python3-pytest gettext build-essential
     # Optional dependencies for more features:
     $ apt-get install libelf-dev libglib2.0-dev libblkid-dev libjson-glib-1.0 libjson-glib-dev
     # Optional dependencies for the GUI:

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -5,7 +5,7 @@ Testsuite
 complete yet (and probably never will), but it's already a valuable boost of
 confidence in ``rmlint's`` correctness.
 
-The tests are based on ``nosetest`` and are written in ``python>=3.0``.
+The tests are based on ``pytest`` and are written in ``python>=3.0``.
 Every testcase just runs the (previously built) ``rmlint`` binary a
 and parses its json output. So they are technically blackbox-tests.
 
@@ -34,17 +34,17 @@ variables which are:
 - ``RM_TS_PRINT_CMD``: Print the command that is currently run.
 - ``RM_TS_KEEP_TESTDIR``: If a test failed, keep the test files.
 
-Additionally slow tests can be omitted with by appending ``-a '!slow'`` to 
-the commandline. More information on this syntax can be found on the `nosetest
+Additionally slow tests can be omitted with by appending ``-k 'not slow'`` to
+the commandline. More information on this syntax can be found on the `pytest
 documentation`_.
 
-.. _`nosetest documentation`: http://nose.readthedocs.org/en/latest/plugins/attrib.html
+.. _`pytest documentation`: https://docs.pytest.org/en/stable/example/markers.html
 
 Before each release we call the testsuite (at least) like this:
 
 .. code-block:: bash
 
-   $ sudo RM_TS_USE_VALGRIND=1 RM_TS_PRINT_CMD=1 RM_TS_PEDANTIC=1 nosetests-3.4 -s -a '!slow !known_issue'
+   $ sudo RM_TS_USE_VALGRIND=1 RM_TS_PRINT_CMD=1 RM_TS_PEDANTIC=1 pytest -s -a 'not slow and not known_issue'
 
 The ``sudo`` here is there for executing some tests that need root access (like
 the creating of bad user and group ids). Most tests will work without.
@@ -59,7 +59,7 @@ were executed (and how often) by the testsuite. Here's a short quickstart using
 .. code-block:: bash
 
     $ CFLAGS="-fprofile-arcs -ftest-coverage" LDFLAGS="-fprofile-arcs -ftest-coverage" scons -j4 DEBUG=1
-    $ sudo RM_TS_USE_VALGRIND=1 RM_TS_PRINT_CMD=1 RM_TS_PEDANTIC=1 nosetests-3.4 -s -a '!slow !known_issue'
+    $ sudo RM_TS_USE_VALGRIND=1 RM_TS_PRINT_CMD=1 RM_TS_PEDANTIC=1 pytest -s -a 'slow and not known_issue'
     $ lcov --capture --directory . --output-file coverage.info
     $ genhtml coverage.info --output-directory out
 
@@ -85,11 +85,9 @@ A template for a testcase looks like this:
 
 .. code-block:: python
 
-    from nose import with_setup
     from tests.utils import *
 
-    @with_setup(usual_setup_func, usual_teardown_func)
-    def test_basic():
+    def test_basic(usual_setup_usual_teardown):
         create_file('xxx', 'a')
         create_file('xxx', 'b')
 
@@ -117,11 +115,10 @@ Rules
 
   .. code-block:: python
 
-    from nose.plugins.attrib import attr
+    import pytest
 
-    @attr('slow')
-    @with_setup(usual_setup_func, usual_teardown_func)
-    def test_debian_support():
+    @pytest.mark.slow
+    def test_debian_support(usual_setup_usual_teardown):
         assert random.choice([True, False]):
 
 * Unresolved issues can be marked with `known_issue` attribute to avoid failing automated travis testing

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    slow: slow tests.

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -17,14 +17,14 @@ def cmd_exists(cmd):
 
 
 def run_tests(target=None, source=None, env=None):
-    names = ['nosetests-3.3', 'nosetests-3', 'python3-nosetests', 'nosetests3', 'nosetests']
+    names = ["pytest"]
     exes = [exe for exe in names if cmd_exists(exe)]
     if any(exes):
         name = exes[0]
-        print('Found nosetests as "{}"'.format(name))
-        Exit(subprocess.call(name + ' -s -v -a !slow', shell=True))
+        print('Found pytest as "{}"'.format(name))
+        Exit(subprocess.call(name + ' -s -v -k "not slow"', shell=True))
 
-    print('Unable to find nosetests, tried these: ' + str(names))
+    print('Unable to find pytest, tried these: ' + str(names))
     Exit(-1)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,26 @@
 import pytest
-from tests.utils import cleanup_testdir, create_testdir
+import tests.utils as utils
 
 @pytest.fixture(autouse=True)
 def with_cleanup_between_runs():
-    cleanup_testdir()
-    create_testdir()
+    utils.cleanup_testdir()
+    utils.create_testdir()
+
+
+@pytest.fixture(params=["sh", "bash", "dash"])
+def shell(request):
+    yield request.param
+
+
+@pytest.fixture
+def usual_setup_usual_teardown():
+    utils.usual_setup_func()
+    yield
+    utils.usual_teardown_func()
+
+
+@pytest.fixture
+def usual_setup_mount_bind_teardown():
+    utils.usual_setup_func()
+    yield
+    utils.mount_bind_teardown_func()

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,3 @@
-nose==1.3.7
-pytest==8.3.4
-parameterized==0.6.1
 xattr==0.9.6
 psutil==5.6.6
+pytest==8.3.5

--- a/tests/test_formatters/test_csv.py
+++ b/tests/test_formatters/test_csv.py
@@ -1,17 +1,15 @@
 #!/usr/bin/env python3
-# encoding: utf-8
-from nose import with_setup
+import csv
+
 from tests.utils import *
 
-import csv
 
 def csv_string_to_data(csv_dump):
     data = list(csv.reader(csv_dump.splitlines()))
     return data[1:]
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_simple():
+def test_simple(usual_setup_usual_teardown):
     create_file('1234', 'a')
     create_file('1234', 'b')
     create_file('1234', 'stupid\'file,name')
@@ -40,8 +38,7 @@ def test_simple():
 
 
 # regression test for GitHub issue #496
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_no_checksum():
+def test_no_checksum(usual_setup_usual_teardown):
     # rmlint will not (normally) hash files with no same-sized siblings
     create_file('x', 'a')
     create_file('yy', 'b')

--- a/tests/test_formatters/test_json.py
+++ b/tests/test_formatters/test_json.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
-# encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_simple():
+def test_simple(usual_setup_usual_teardown):
     full_path_a = create_file('x', '\t\r\"\b\f\\')
     full_path_b = create_file('x', '\"\t\n2134124')
     head, *data, footer = run_rmlint('-S a')

--- a/tests/test_formatters/test_others.py
+++ b/tests/test_formatters/test_others.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
-# encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_just_call_it():
+def test_just_call_it(usual_setup_usual_teardown):
     create_file('1234', 'a')
     create_file('1234', 'b')
 

--- a/tests/test_formatters/test_py.py
+++ b/tests/test_formatters/test_py.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
-# encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 
 import subprocess
-
-from parameterized import parameterized
+import pytest
 
 
 def _check_interpreter(interpreter):
@@ -16,16 +13,14 @@ def _check_interpreter(interpreter):
         return False
 
 
-@parameterized(["python2", "python3"])
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_paranoia(interpreter):
+@pytest.mark.parametrize("interpreter", ["python2", "python3"])
+def test_paranoia(usual_setup_usual_teardown, interpreter):
     if not _check_interpreter(interpreter):
-        print(
+        pytest.skip(
             "Interpreter {} does not seem to be working, skipping test".format(
                 interpreter
             )
         )
-        return
 
     create_file('xxx', 'a')
     create_file('xxx', 'b')

--- a/tests/test_formatters/test_sh.py
+++ b/tests/test_formatters/test_sh.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python3
-# encoding: utf-8
+from tests.utils import *
 
 import shlex
 import subprocess
-
-from nose import with_setup
-from parameterized import parameterized
-from tests.utils import *
+import pytest
 
 
 def run_shell_script(shell, sh_path, *args):
@@ -22,9 +19,7 @@ def filter_part_of_directory(data):
     return [e for e in data if e['type'] != 'part_of_directory']
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-@parameterized([("sh", ), ("bash", ), ("dash", )])
-def test_basic(shell):
+def test_basic(usual_setup_usual_teardown, shell):
     create_file('xxx', 'a')
     create_file('xxx', 'b')
 
@@ -72,9 +67,7 @@ def test_basic(shell):
     assert '/a' in text
 
 
-@parameterized([("sh", ), ("bash", ), ("dash", )])
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_paranoia(shell):
+def test_paranoia(usual_setup_usual_teardown, shell):
     create_file('xxx', 'a')
     create_file('xxx', 'b')
     create_file('xxx', 'c')
@@ -125,8 +118,7 @@ def test_paranoia(shell):
     assert footer['duplicates'] == 0
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_anon_pipe():
+def test_anon_pipe(usual_setup_usual_teardown):
     create_file('xxx', 'long-dummy-file-1')
     create_file('xxx', 'long-dummy-file-2')
 
@@ -141,9 +133,7 @@ def test_anon_pipe():
     assert b'/long-dummy-file-2' in data
 
 
-@parameterized([("sh", ), ("bash", ), ("dash", )])
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_hardlink_duplicate_directories(shell):
+def test_hardlink_duplicate_directories(usual_setup_usual_teardown, shell):
     create_file('xxx', 'dir_a/x')
     create_file('xxx', 'dir_b/x')
 
@@ -175,12 +165,8 @@ def _check_if_empty_dirs_deleted(shell, inverse_order, sh_path, data):
         assert not os.path.exists(data[1]["path"])
 
 
-@parameterized([
-    ("sh", False), ("bash", False), ("dash", False),
-    ("sh", True), ("bash", True), ("dash", True)
-])
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_remove_empty_dirs(shell, inverse_order):
+@pytest.mark.parametrize("inverse_order", [False, True])
+def test_remove_empty_dirs(usual_setup_usual_teardown, shell, inverse_order):
     create_file('xxx', 'deep/a/b/c/d/e/1')
     create_file('xxx', 'deep/x/2')
 
@@ -208,12 +194,8 @@ def test_remove_empty_dirs(shell, inverse_order):
     _check_if_empty_dirs_deleted(shell, inverse_order, sh_path, data)
 
 
-@parameterized([
-    ("sh", False), ("bash", False), ("dash", False),
-    ("sh", True), ("bash", True), ("dash", True)
-])
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_remove_empty_dirs_with_dupe_dirs(shell, inverse_order):
+@pytest.mark.parametrize("inverse_order", [False, True])
+def test_remove_empty_dirs_with_dupe_dirs(usual_setup_usual_teardown, shell, inverse_order):
     create_file('xxx', 'deep/a/b/c/d/e/1')
     create_file('xxx', 'deep/x/1')
 
@@ -241,9 +223,7 @@ def test_remove_empty_dirs_with_dupe_dirs(shell, inverse_order):
 
     _check_if_empty_dirs_deleted(shell, inverse_order, sh_path, data)
 
-@with_setup(usual_setup_func, usual_teardown_func)
-@parameterized([("sh", ), ("bash", ), ("dash", )])
-def test_cleanup_emptydirs(shell):
+def test_cleanup_emptydirs(usual_setup_usual_teardown, shell):
     create_file('xxx', 'dir1/a')
 
     # create some ugly dir names
@@ -272,9 +252,7 @@ def test_cleanup_emptydirs(shell):
 
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-@parameterized([("sh", ), ("bash", ), ("dash", )])
-def test_keep_parent_timestamps(shell):
+def test_keep_parent_timestamps(usual_setup_usual_teardown, shell):
     create_file('xxx', 'dir/a')
     create_file('xxx', 'dir/b')
 
@@ -295,9 +273,8 @@ def test_keep_parent_timestamps(shell):
 
 
 # regression test for GitHub issue #545
-@parameterized.expand([('',), ('-D',)])
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_skip_hardlinks(tm_opt):
+@pytest.mark.parametrize("tm_opt", ('', '-D'))
+def test_skip_hardlinks(usual_setup_usual_teardown, tm_opt):
     dir_a = create_dirs('a')
     create_file('xxx', 'a/1')
     create_file('yyy', 'a/2')

--- a/tests/test_mains/test_dedupe.py
+++ b/tests/test_mains/test_dedupe.py
@@ -1,15 +1,7 @@
 #!/usr/bin/env python3
-# encoding: utf-8
-
-from nose import with_setup
-import re
-
 from tests.utils import *
 
-
-@needs_reflink_fs
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_equal_files():
+def test_equal_files(usual_setup_usual_teardown, needs_reflink_fs):
     path_a = create_file('1234', 'a')
     path_b = create_file('1234', 'b')
 
@@ -29,9 +21,7 @@ def test_equal_files():
             with_json=False)
 
 
-@needs_reflink_fs
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_different_files():
+def test_different_files(usual_setup_usual_teardown, needs_reflink_fs):
     path_a = create_file('1234', 'a')
     path_b = create_file('4321', 'b')
 
@@ -44,9 +34,7 @@ def test_different_files():
             verbosity="")
 
 
-@needs_reflink_fs
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_bad_arguments():
+def test_bad_arguments(usual_setup_usual_teardown, needs_reflink_fs):
     path_a = create_file('1234', 'a')
     path_b = create_file('1234', 'b')
     path_c = create_file('1234', 'c')
@@ -64,9 +52,7 @@ def test_bad_arguments():
                 verbosity="")
 
 
-@needs_reflink_fs
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_directories():
+def test_directories(usual_setup_usual_teardown, needs_reflink_fs):
     path_a = os.path.dirname(create_dirs('dir_a'))
     path_b = os.path.dirname(create_dirs('dir_b'))
 
@@ -79,9 +65,7 @@ def test_directories():
             verbosity="")
 
 
-@needs_reflink_fs
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_dedupe_works():
+def test_dedupe_works(usual_setup_usual_teardown, needs_reflink_fs):
 
     # test files need to be larger than btrfs node size to prevent inline extents
     path_a = create_file('1' * 100000, 'a')
@@ -115,9 +99,7 @@ def test_dedupe_works():
         )
 
 
-@needs_reflink_fs
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_clone_handler():
+def test_clone_handler(usual_setup_usual_teardown, needs_reflink_fs):
     # test files need to be larger than btrfs node size to prevent inline extents
     path_a = create_file('1' * 100000, 'a')
     path_b = create_file('1' * 100000, 'b')

--- a/tests/test_mains/test_hash.py
+++ b/tests/test_mains/test_hash.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-
-from nose import with_setup
 from tests.utils import *
-from nose.plugins.attrib import attr
-from parameterized import parameterized
+
+import pytest
 
 INCREMENTS = [4096, 1024, 1, 20000]
 
@@ -29,7 +27,7 @@ def streaming_compliance_check(patterns):
                 assert False, "{} fails streaming test with increment {}".format(algo, increment)
                 break
 
-@parameterized([
+@pytest.mark.parametrize("pat", [
         'murmur',
         'metro',
         ['glib:', 'md5', 'sha1', 'sha256', 'sha512'],
@@ -38,7 +36,7 @@ def streaming_compliance_check(patterns):
         'xxhash',
         'highway'
         ])
-def test_hash_function(*pat):
+def test_hash_function(usual_setup_usual_teardown, pat):
     if(len(pat)==1):
         streaming_compliance_check(pat)
     else:

--- a/tests/test_mains/test_is_reflink.py
+++ b/tests/test_mains/test_is_reflink.py
@@ -1,8 +1,5 @@
-# encoding: utf-8
-
 import os
 import subprocess
-from nose import with_setup
 from tests.utils import *
 
 
@@ -16,8 +13,7 @@ def check_is_reflink_status(status_code, *paths):
         )
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_bad_arguments():
+def test_bad_arguments(usual_setup_usual_teardown):
     path_a = create_file('xxx', 'a')
     path_b = create_file('xxx', 'b')
     path_c = create_file('xxx', 'c')
@@ -29,28 +25,24 @@ def test_bad_arguments():
         check_is_reflink_status(1, *paths)  # RM_LINK_NONE
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_directories():
+def test_directories(usual_setup_usual_teardown):
     path_a = create_dirs('dir_a')
     path_b = create_dirs('dir_b')
     check_is_reflink_status(3, path_a, path_b)  # RM_LINK_NOT_FILE
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_different_sizes():
+def test_different_sizes(usual_setup_usual_teardown):
     path_a = create_file('xxx', 'a')
     path_b = create_file('xxxx', 'b')
     check_is_reflink_status(4, path_a, path_b)  # RM_LINK_WRONG_SIZE
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_same_path():
+def test_same_path(usual_setup_usual_teardown):
     path_a = create_file('xxx', 'a')
     check_is_reflink_status(6, path_a, path_a)  # RM_LINK_SAME_FILE
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_path_double():
+def test_path_double(usual_setup_usual_teardown):
     path_a = create_file('xxx', 'dir/a')
     create_link('dir', 'dir_symlink', symlink=True)
     path_b = os.path.join(TESTDIR_NAME, 'dir_symlink/a')
@@ -68,16 +60,14 @@ def test_path_double():
         assert False
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_hardlinks():
+def test_hardlinks(usual_setup_usual_teardown):
     path_a = create_file('xxx', 'a')
     path_b = path_a + '_hardlink'
     create_link('a', 'a_hardlink', symlink=False)
     check_is_reflink_status(8, path_a, path_b)  # RM_LINK_HARDLINK
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_symlink():
+def test_symlink(usual_setup_usual_teardown):
     path_a = create_file('xxx', 'a')
     path_b = create_file('xxx', 'b') + '_symlink'
     create_link('b', 'b_symlink', symlink=True)
@@ -116,23 +106,17 @@ def _make_reflink_testcase(extents, hole_extents=None, break_link=False):
 
 
 # GitHub issue #527: Make sure rmlint does not skip every other extent.
-@needs_reflink_fs
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_second_extent_differs():
+def test_second_extent_differs(usual_setup_usual_teardown, needs_reflink_fs):
     _make_reflink_testcase(extents=5, break_link=True)
 
 
 # GitHub issue #528, part 1: Make sure the last extent is not ignored.
-@needs_reflink_fs
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_last_extent_differs():
+def test_last_extent_differs(usual_setup_usual_teardown, needs_reflink_fs):
     _make_reflink_testcase(extents=2, break_link=True)
 
 
 # GitHub issue #528, part 2: Make sure files that end in a hole can be identified as reflinked.
-@needs_reflink_fs
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_reflink_ends_with_hole():
+def test_reflink_ends_with_hole(usual_setup_usual_teardown, needs_reflink_fs):
     _make_reflink_testcase(extents=1, hole_extents=1)
 
 
@@ -164,9 +148,7 @@ def _hole_testcase_inner(extents):
 
 # GitHub issue #611: Make sure holes can be detected when the physical offsets and logical
 # extent ends are otherwise the same.
-@needs_reflink_fs
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_hole_before_extent():
+def test_hole_before_extent(usual_setup_usual_teardown, needs_reflink_fs):
     for infd, outfd in _hole_testcase_inner(extents=2):
         # copy first half of first extent with 4K offset
         _copy_file_range(infd, outfd, kb(4), kb(0), kb(4))
@@ -176,9 +158,7 @@ def test_hole_before_extent():
 
 # GitHub issue #530: Make sure physically adjacent extents aren't merged if there is a
 # hole between them logically.
-@needs_reflink_fs
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_hole_between_extents():
+def test_hole_between_extents(usual_setup_usual_teardown, needs_reflink_fs):
     for infd, outfd in _hole_testcase_inner(extents=1):
         # copy first extent
         _copy_file_range(infd, outfd, kb(8), kb(0), kb(0))
@@ -186,8 +166,7 @@ def test_hole_between_extents():
         _copy_file_range(infd, outfd, kb(4), kb(8), kb(12))
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_default_outputs_disabled():
+def test_default_outputs_disabled(usual_setup_usual_teardown):
     create_file('xxx', 'a')
     create_file('xxx', 'b')
 

--- a/tests/test_options/test_cache.py
+++ b/tests/test_options/test_cache.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python3
-# encoding: utf-8
-
 import os
 import subprocess
+import pytest
 
-from nose import with_setup
 from tests.utils import *
-from parameterized import parameterized
 
 
 def create_files():
@@ -60,8 +57,7 @@ def check(data, write_cache):
     assert path_in('4.d', dupe_files)
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_xattr_basic():
+def test_xattr_basic(usual_setup_usual_teardown):
     create_files()
 
     for _ in range(2):
@@ -76,9 +72,8 @@ def test_xattr_basic():
         head, *data, footer = run_rmlint('-D -S pa --xattr-clear')
 
 
-@parameterized([("", ), ("-D", )])
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_xattr_detail(extra_opts):
+@pytest.mark.parametrize("extra_opts", ["", "-D"])
+def test_xattr_detail(usual_setup_usual_teardown, extra_opts):
     if not runs_as_root():
         # This tests need a ext4 fs which is created during the test.
         # The mount step sadly needs root privileges.
@@ -145,8 +140,7 @@ def test_xattr_detail(extra_opts):
 
 # regression test for GitHub issue #475
 # NB: this test is only effective if RM_TS_DIR is on an xattr-capable filesystem
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_treemerge_xattr_hardlink():
+def test_treemerge_xattr_hardlink(usual_setup_usual_teardown):
     create_file('xxx', 'a/x')
     create_file('yyy', 'a/y')
     create_file('xxx', 'b/x')
@@ -165,9 +159,8 @@ def test_treemerge_xattr_hardlink():
 
 
 # NB: this test is only effective if RM_TS_DIR is on an xattr-capable filesystem
-@parameterized([('-q 1',), ('-Q 1',), ('-q 50%',), ('-Q 50%',)])
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_clamp_xattr_false_negative(clamp):
+@pytest.mark.parametrize("clamp", ['-q 1', '-Q 1', '-q 50%', '-Q 50%'])
+def test_clamp_xattr_false_negative(usual_setup_usual_teardown, clamp):
     create_file('xxx', 'a')
     create_file('yyy', 'b')
 
@@ -187,9 +180,8 @@ def test_clamp_xattr_false_negative(clamp):
 
 
 # NB: this test is only effective if RM_TS_DIR is on an xattr-capable filesystem
-@parameterized([('-q 2',), ('-Q 1',), ('-q 70%',), ('-Q 50%',)])
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_clamp_xattr_false_positive(clamp):
+@pytest.mark.parametrize("clamp", ['-q 2', '-Q 1', '-q 70%', '-Q 50%'])
+def test_clamp_xattr_false_positive(usual_setup_usual_teardown, clamp):
     # directories 'a' and 'b' obviously do not match
     # extra files are needed to satisfy preprocessing, which compares file size
     create_file('xxx', '1')

--- a/tests/test_options/test_clamp.py
+++ b/tests/test_options/test_clamp.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
-# encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_simple():
+def test_simple(usual_setup_usual_teardown):
     create_file('1234567890', 'a10')
     create_file('x23456789x', 'b10')
 
@@ -19,8 +16,7 @@ def test_simple():
         assert len(data) == 2
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_almost_empty():
+def test_almost_empty(usual_setup_usual_teardown):
     create_file('x', 'a1')
     create_file('x', 'b1')
 
@@ -33,8 +29,7 @@ def test_almost_empty():
     assert footer['total_files'] == 0
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_absolute():
+def test_absolute(usual_setup_usual_teardown):
     data1 = ['x'] * 2048
     data2 = ['x'] * 2048
     data2[1023] = 'y'
@@ -59,8 +54,7 @@ def test_absolute():
     assert len(data) == 0
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_clamped_to_empty():
+def test_clamped_to_empty(usual_setup_usual_teardown):
     create_file('x', 'empties/a')
     create_file('x', 'empties/b')
 

--- a/tests/test_options/test_color.py
+++ b/tests/test_options/test_color.py
@@ -1,13 +1,7 @@
-# encoding: utf-8
-
-import os
-
-from nose import with_setup
 from tests.utils import *
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_color():
+def test_color(usual_setup_usual_teardown):
     # color disabled by pipe
     output = run_rmlint('-o summary', with_json=False, directly_return_output=True)
     assert b'\x1b[' not in output
@@ -17,8 +11,7 @@ def test_color():
     assert b'\x1b[' not in output
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_no_color_crash():
+def test_no_color_crash(usual_setup_usual_teardown):
     # cause rmlint to fail with a simple error message, without color
     result, _ = run_rmlint_once('-kK --no-with-color', with_json=False, check=False, verbosity='')
     assert result.returncode == 1  # should not be a segfault or any other fatal signal

--- a/tests/test_options/test_equal.py
+++ b/tests/test_options/test_equal.py
@@ -1,16 +1,9 @@
 #!/usr/bin/env python3
-# encoding: utf-8
 import os
-import json
-
-from nose import with_setup
-from contextlib import contextmanager
 
 from tests.utils import *
 
-
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_equal_files():
+def test_equal_files(usual_setup_usual_teardown):
     path_a = create_file('1234', 'a')
     path_b = create_file('1234', 'b')
 
@@ -47,8 +40,7 @@ def test_equal_files():
         )
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_no_arguments():
+def test_no_arguments(usual_setup_usual_teardown):
     with assert_exit_code(1):
         head, *data, footer = run_rmlint(
             '--equal',
@@ -56,8 +48,7 @@ def test_no_arguments():
         )
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_one_arguments():
+def test_one_arguments(usual_setup_usual_teardown):
     path = create_file('1234', 'a')
     with assert_exit_code(1):
         head, *data, footer = run_rmlint(
@@ -78,8 +69,7 @@ def test_one_arguments():
         )
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_equal_directories():
+def test_equal_directories(usual_setup_usual_teardown):
     path_a = os.path.dirname(create_file('xxx', 'dir_a/x'))
     path_b = os.path.dirname(create_file('xxx', 'dir_b/x'))
 
@@ -96,8 +86,7 @@ def test_equal_directories():
         )
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_dir_and_file():
+def test_dir_and_file(usual_setup_usual_teardown):
     path_a = os.path.dirname(create_file('xxx', 'dir_a/x'))
     path_b = create_file('xxx', 'x')
 
@@ -111,8 +100,7 @@ def test_dir_and_file():
 
 
 # Regression test for Issue #233
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_equal_hidden_dirs():
+def test_equal_hidden_dirs(usual_setup_usual_teardown):
     path_a = os.path.dirname(create_file('xxx', 'dir_a/x'))
     path_b = os.path.dirname(create_file('xxx', '.dir_b/.x'))
 
@@ -126,8 +114,7 @@ def test_equal_hidden_dirs():
 
 
 # Regression test for Issue #234
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_equal_empty_files_or_other_lint():
+def test_equal_empty_files_or_other_lint(usual_setup_usual_teardown):
     path_a = create_file('', 'x')
     path_b = create_file('', 'y')
 
@@ -141,8 +128,7 @@ def test_equal_empty_files_or_other_lint():
 
 
 # regression test for GitHub issue #552
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_default_outputs_disabled():
+def test_default_outputs_disabled(usual_setup_usual_teardown):
     create_file('xxx', 'a')
     create_file('xxx', 'b')
 

--- a/tests/test_options/test_help.py
+++ b/tests/test_options/test_help.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 
 # These tests are only here to check if printing help works.
 # Well, actually it's to increase coverage to be honest.
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_help():
+def test_help(usual_setup_usual_teardown):
     yelp = subprocess.check_output(
         ['./rmlint', '--help'], stderr=subprocess.STDOUT
     ).decode('utf-8')
@@ -16,8 +14,7 @@ def test_help():
     assert '--show-man' in yelp
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_man():
+def test_man(usual_setup_usual_teardown):
     yelp = subprocess.check_output(
         ['./rmlint', '--show-man'], stderr=subprocess.STDOUT
     ).decode('utf-8')

--- a/tests/test_options/test_hidden_dirs.py
+++ b/tests/test_options/test_hidden_dirs.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 
 
@@ -8,8 +7,7 @@ def filter_part_of_directory(data):
     return [e for e in data if e['type'] != 'part_of_directory']
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_simple():
+def test_simple(usual_setup_usual_teardown):
     create_file('xxx', '.a/1')
     create_file('xxx', '.b/1')
     create_file('xxx', '.1')
@@ -22,8 +20,7 @@ def test_simple():
     assert footer['duplicate_sets'] == 1
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_hidden():
+def test_hidden(usual_setup_usual_teardown):
     create_file('xxx', '.a/1')
     create_file('xxx', '.b/1')
     create_file('xxx', '.1')
@@ -35,8 +32,7 @@ def test_hidden():
     assert footer['duplicate_sets'] == 0
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_explicit():
+def test_explicit(usual_setup_usual_teardown):
     create_file('xxx', '.a/1')
     create_file('xxx', '.a/2')
     head, *data, footer = run_rmlint('--no-hidden', dir_suffix='.a')
@@ -47,8 +43,7 @@ def test_explicit():
     assert footer['duplicate_sets'] == 1
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_partial_hidden():
+def test_partial_hidden(usual_setup_usual_teardown):
     create_file('1', 'a/.hidden')
     create_file('1', 'b/.hidden')
     create_file('1', '.hidden')

--- a/tests/test_options/test_keep_hardlinks.py
+++ b/tests/test_options/test_keep_hardlinks.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_keep_hardlinks():
+def test_keep_hardlinks(usual_setup_usual_teardown):
     create_file('xxx', 'file_a')
     create_link('file_a', 'file_b')
     create_file('xxx', 'file_z')

--- a/tests/test_options/test_km.py
+++ b/tests/test_options/test_km.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_km():
+def test_km(usual_setup_usual_teardown):
     # create some dupes with different paths, names and mtimes:
     create_file('xxx', 'stuff/a')
     create_file('yyy', 'stuff/b')

--- a/tests/test_options/test_match_basenames.py
+++ b/tests/test_options/test_match_basenames.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_negative_with_basename():
+def test_negative_with_basename(usual_setup_usual_teardown):
     create_file('xxx', 'a')
     create_file('xxx', 'b')
     head, *data, footer = run_rmlint('-b')
@@ -13,8 +11,7 @@ def test_negative_with_basename():
     assert footer['duplicates'] == 0
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_positive_with_basename():
+def test_positive_with_basename(usual_setup_usual_teardown):
     create_file('xxx', 'a/test')
     create_file('xxx', 'b/test')
     head, *data, footer = run_rmlint('-b')
@@ -23,8 +20,7 @@ def test_positive_with_basename():
     assert footer['duplicates'] == 1
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_negative_without_basename():
+def test_negative_without_basename(usual_setup_usual_teardown):
     create_file('xxx', 'a/test')
     create_file('xxx', 'b/test')
     head, *data, footer = run_rmlint('-B')
@@ -33,8 +29,7 @@ def test_negative_without_basename():
     assert footer['duplicates'] == 0
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_positive_without_basename():
+def test_positive_without_basename(usual_setup_usual_teardown):
     create_file('xxx', 'a/test1')
     create_file('xxx', 'b/test2')
     head, *data, footer = run_rmlint('-B')

--- a/tests/test_options/test_match_with_extension.py
+++ b/tests/test_options/test_match_with_extension.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_negative():
+def test_negative(usual_setup_usual_teardown):
     create_file('xxx', 'a.png')
     create_file('xxx', 'b.jpg')
     create_file('xxx', 'b')
@@ -14,8 +12,7 @@ def test_negative():
     assert footer['duplicates'] == 0
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_positive():
+def test_positive(usual_setup_usual_teardown):
     create_file('xxx', 'a.png')
     create_file('xxx', 'b.png')
     head, *data, footer = run_rmlint('-e')

--- a/tests/test_options/test_match_without_extension.py
+++ b/tests/test_options/test_match_without_extension.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_negative():
+def test_negative(usual_setup_usual_teardown):
     create_file('xxx', 'b.png')
     create_file('xxx', 'a.png')
     create_file('xxx', 'a')
@@ -14,8 +12,7 @@ def test_negative():
     assert footer['duplicates'] == 0
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_positive():
+def test_positive(usual_setup_usual_teardown):
     create_file('xxx', 'a.png')
     create_file('xxx', 'a.jpg')
     head, *data, footer = run_rmlint('-i')

--- a/tests/test_options/test_merge_directories.py
+++ b/tests/test_options/test_merge_directories.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python3
-# encoding: utf-8
-from nose import with_setup
-from parameterized import parameterized
 from tests.utils import *
 
 
@@ -12,9 +9,8 @@ def filter_part_of_directory(data):
 
 
 # --write-unfinished variant is a regression test for GitHub issue #562
-@parameterized([((),), (('--write-unfinished',),)])
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_simple(extra_opts):
+@pytest.mark.parametrize('extra_opts', [(), ('--write-unfinished',)])
+def test_simple(usual_setup_usual_teardown, extra_opts):
     create_file('xxx', '1/a')
     create_file('xxx', '2/a')
     create_file('xxx', 'a')
@@ -36,8 +32,7 @@ def test_simple(extra_opts):
     assert data[1]['path'].endswith('1')
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_diff():
+def test_diff(usual_setup_usual_teardown):
     create_file('xxx', '1/a')
     create_file('xxx', '2/a')
     create_file('xxx', '3/a')
@@ -55,8 +50,7 @@ def test_diff():
     assert data[1]['path'].endswith('1')
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_same_but_not_dupe():
+def test_same_but_not_dupe(usual_setup_usual_teardown):
     create_file('xxx', '1/a')
     create_file('xxx', '2/a')
     create_file('xxx', '2/b')
@@ -67,8 +61,7 @@ def test_same_but_not_dupe():
     assert 0 == sum(find['type'] == 'duplicate_dir' for find in data)
     assert 3 == sum(find['type'] == 'duplicate_file' for find in data)
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_hardlinks():
+def test_hardlinks(usual_setup_usual_teardown):
     create_file('xxx', '1/a')
     create_link('1/a', '1/link1')
     create_link('1/a', '1/link2')
@@ -104,8 +97,7 @@ def test_hardlinks():
     assert data[1]['path'].endswith('a')
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_deep_simple():
+def test_deep_simple(usual_setup_usual_teardown):
     create_file('xxx', 'deep/a/b/c/d/1')
     create_file('xxx', 'deep/e/f/g/h/1')
     head, *data, footer = run_rmlint('-D -S a')
@@ -118,8 +110,7 @@ def test_deep_simple():
     assert len(data) == 2
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_deep_simple():
+def test_deep_simple(usual_setup_usual_teardown):
     create_file('xxx', 'd/a/1')
     create_file('xxx', 'd/b/empty')
     create_file('xxx', 'd/a/1')
@@ -132,8 +123,7 @@ def test_deep_simple():
     assert len(data) == 2
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_dirs_with_empty_files_only():
+def test_dirs_with_empty_files_only(usual_setup_usual_teardown):
     create_file('', 'a/empty')
     create_file('', 'b/empty')
     head, *data, footer = run_rmlint('-p -D -S a -T df,dd --size 0')
@@ -168,8 +158,7 @@ def create_nested(root, letters):
         create_file('xxx', path)
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_deep_full():
+def test_deep_full(usual_setup_usual_teardown):
     create_nested('deep', 'abcd')
     create_nested('deep', 'efgh')
 
@@ -193,8 +182,7 @@ def test_deep_full():
         assert data[idx + 2]['is_original'] == (idx == 0)
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_deep_full_twice():
+def test_deep_full_twice(usual_setup_usual_teardown):
     create_nested('deep_a', 'abcd')
     create_nested('deep_a', 'efgh')
     create_nested('deep_b', 'abcd')
@@ -239,8 +227,7 @@ def test_deep_full_twice():
     assert not data[3]['is_original']
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_symlinks():
+def test_symlinks(usual_setup_usual_teardown):
     create_file('xxx', 'a/z')
     create_link('a/z', 'a/x', symlink=True)
     create_file('xxx', 'b/z')
@@ -265,20 +252,7 @@ def test_symlinks():
     assert not data[1]['is_original']
 
 
-def mount_bind_teardown_func():
-    if runs_as_root():
-        subprocess.call(
-            'umount {dst}'.format(
-                dst=os.path.join(TESTDIR_NAME, 'a/b')
-            ),
-            shell=True
-        )
-
-    usual_teardown_func()
-
-
-@with_setup(usual_setup_func, mount_bind_teardown_func)
-def test_mount_binds():
+def test_mount_binds(usual_setup_mount_bind_teardown):
     if not runs_as_root():
         return
 
@@ -300,8 +274,7 @@ def test_mount_binds():
     assert len(data) == 2
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_keepall_tagged():
+def test_keepall_tagged(usual_setup_usual_teardown):
     # Test for Issue #141:
     # https://github.com/sahib/rmlint/issues/141
     #
@@ -433,8 +406,7 @@ def test_keepall_tagged():
     assert footer['duplicate_sets'] == 0
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_equal_content_different_layout():
+def test_equal_content_different_layout(usual_setup_usual_teardown):
     # Different duplicates in different subdirs.
     create_file('xxx', "tree-a/sub2/x")
     create_file('yyy', "tree-a/sub1/y")
@@ -466,8 +438,7 @@ def test_equal_content_different_layout():
         assert point["type"] == "duplicate_file"
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_nested_content_with_same_layout():
+def test_nested_content_with_same_layout(usual_setup_usual_teardown):
     create_nested('deep', 'xyzabc')
     create_nested('deep', 'uvwabc')
 

--- a/tests/test_options/test_mtime_window.py
+++ b/tests/test_options/test_mtime_window.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose.plugins.attrib import attr
-from nose import with_setup
 from tests.utils import *
 
 import os
@@ -13,8 +11,7 @@ def set_mtime(path, mtime):
     subprocess.call(['touch', '-m', '-d', str(mtime), full_path])
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_consider_mtime():
+def test_consider_mtime(usual_setup_usual_teardown):
     create_file('xxx', 'a')
     create_file('xxx', 'b')
     create_file('xxx', 'c')
@@ -54,8 +51,7 @@ def test_consider_mtime():
     assert footer['duplicate_sets'] == 1
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_consider_mtime_subsecond():
+def test_consider_mtime_subsecond(usual_setup_usual_teardown):
     create_file('xxx', 'a')
     create_file('xxx', 'b')
 
@@ -74,8 +70,7 @@ def test_consider_mtime_subsecond():
     head, *data, footer = run_rmlint('--mtime-window=0')
     assert len(data) == 0
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_consider_mtime_fail_by_association():
+def test_consider_mtime_fail_by_association(usual_setup_usual_teardown):
     create_file('xxx', 'a')
     create_file('yyy', 'b')
     create_file('xxx', 'c')
@@ -92,8 +87,7 @@ def test_consider_mtime_fail_by_association():
     assert footer['duplicates'] == 0
     assert footer['duplicate_sets'] == 0
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_mtime_and_unmatched_basenames():
+def test_mtime_and_unmatched_basenames(usual_setup_usual_teardown):
     create_file('xxx', 'dir1/a')
     create_file('xxx', 'dir1/c')
     create_file('xxx', 'dir2/a')

--- a/tests/test_options/test_newer_than.py
+++ b/tests/test_options/test_newer_than.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 
 import time
@@ -31,8 +30,7 @@ def create_set(create_stamp, iso8601=False):
     warp_file_to_future('c', 2)
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_simple():
+def test_simple(usual_setup_usual_teardown):
     create_set(False)
     now = time.time()
     head, *data, footer = run_rmlint_once('-S a -N ' + str(time.time()))
@@ -50,8 +48,7 @@ def test_simple():
         assert len(data) == expect
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_stamp_file():
+def test_stamp_file(usual_setup_usual_teardown):
     create_set(True, False)
 
     # Wait 3 seconds, so the new stamp file (written by -n)
@@ -66,8 +63,7 @@ def test_stamp_file():
     assert len(data) == 0
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_stamp_file_iso8601():
+def test_stamp_file_iso8601(usual_setup_usual_teardown):
     create_set(True, True)
 
     head, *data, footer = run_rmlint_once('-S a -n ' + os.path.join(TESTDIR_NAME, '.stamp-0'))

--- a/tests/test_options/test_no_backup.py
+++ b/tests/test_options/test_no_backup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 
 import os
@@ -9,8 +8,7 @@ import shutil
 import tempfile
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_backup():
+def test_backup(usual_setup_usual_teardown):
     create_file('content', 'name_x')
     create_file('content', 'name_y')
 

--- a/tests/test_options/test_pass_files.py
+++ b/tests/test_options/test_pass_files.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 import json
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_stdin_read():
+def test_stdin_read(usual_setup_usual_teardown):
     path_a = create_file('1234', 'a')
     path_b = create_file('1234', 'b')
     path_c = create_file('1234', '.hidden')

--- a/tests/test_options/test_perms.py
+++ b/tests/test_options/test_perms.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 
 import stat
@@ -23,8 +22,7 @@ def create_file_with_perms(content, path, permissions):
     os.chmod(os.path.join(TESTDIR_NAME, path), perms)
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_combinations():
+def test_combinations(usual_setup_usual_teardown):
     # This test does not work when run as root.
     # root can read the files anyways.
     if runs_as_root():

--- a/tests/test_options/test_rankby.py
+++ b/tests/test_options/test_rankby.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # encoding: utf-8
 import os
-from nose import with_setup
 from tests.utils import *
 
 
@@ -9,8 +8,7 @@ def filter_part_of_directory(data):
     return [e for e in data if e['type'] != 'part_of_directory']
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_rankby_simple():
+def test_rankby_simple(usual_setup_usual_teardown):
     create_file('x', 'ax')
     create_file('x', 'ay')
     create_file('yyy', 'bx')
@@ -25,8 +23,7 @@ def test_rankby_simple():
     assert paths == ['by', 'bx', 'ay', 'ax']
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_rankby_dirs():
+def test_rankby_dirs(usual_setup_usual_teardown):
     create_file('x', 'ax')
     create_file('x', 'ay')
     create_file('yyy', 'b/x')

--- a/tests/test_options/test_replay.py
+++ b/tests/test_options/test_replay.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose import with_setup
-from nose.plugins.attrib import attr
+import pytest
 from tests.utils import *
 
 import time
@@ -63,8 +62,7 @@ def validate_order(data, tests):
             assert False
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_replay_match_basename():
+def test_replay_match_basename(usual_setup_usual_teardown):
     create_file('xxx', 'test1/a')
     create_file('xxx', 'test1/b')
     create_file('xxx', 'test2/a')
@@ -99,8 +97,7 @@ def test_replay_match_basename():
     assert len(data) == 3
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_replay_hidden():
+def test_replay_hidden(usual_setup_usual_teardown):
     create_file('xxx', 'test/.a')
     create_file('xxx', 'test/.b')
 
@@ -125,8 +122,7 @@ def test_replay_hidden():
     assert len(data) == 2
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_replay_must_match_tagged():
+def test_replay_must_match_tagged(usual_setup_usual_teardown):
     create_file('xxx', 'test_a/a')
     create_file('xxx', 'test_b/a')
 
@@ -149,9 +145,8 @@ def test_replay_must_match_tagged():
     assert (os.path.join(TESTDIR_NAME, 'test_a/a'), True) in paths
 
 
-@attr('slow')
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_sorting():
+@pytest.mark.slow
+def test_sorting(usual_setup_usual_teardown):
     # create some dupes with different PATHS, names and mtimes:
     create_file('xxx', PATHS[0] + 'a')
     create_file('xxx', PATHS[1] + 'bb')
@@ -204,8 +199,7 @@ def test_sorting():
         validate_order(data, combo)
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_replay_no_dir():
+def test_replay_no_dir(usual_setup_usual_teardown):
     # Regression test for #305.
     # --replay did not replay anything when not specifying some path.
     # (The current working directory was not set in this case correctly)
@@ -234,8 +228,7 @@ def test_replay_no_dir():
         os.chdir(current_cwd)
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_replay_unicode_fuckup():
+def test_replay_unicode_fuckup(usual_setup_usual_teardown):
     names = '上野洋子, 吉野裕司, 浅井裕子 & 河越重義', '天谷大輔', 'Аркона'
 
     create_file('xxx', names[0])
@@ -253,8 +246,7 @@ def test_replay_unicode_fuckup():
     assert set([os.path.basename(e['path']) for e in data]) == set(names)
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_replay_tagged_order():
+def test_replay_tagged_order(usual_setup_usual_teardown):
     create_file('xxx', 'a/1')
     create_file('xxx', 'a/2')
     create_file('xxx', 'b/1')
@@ -321,8 +313,7 @@ def test_replay_tagged_order():
     assert data[3]['path'].endswith('a/2')
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_replay_duplicate_directory_size():
+def test_replay_duplicate_directory_size(usual_setup_usual_teardown):
     create_file('xxx', 'a/xxx')
     create_file('xxx', 'b/xxx')
 
@@ -422,8 +413,7 @@ EXPECTED_WITHOUT_TREEMERGE = {
 }
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_replay_pack_directories():
+def test_replay_pack_directories(usual_setup_usual_teardown):
     create_pack_and_unpack_scenario()
 
     # Do a run without -D and pack it later during --replay.
@@ -444,8 +434,7 @@ def test_replay_pack_directories():
     assert data_by_type(data) == EXPECTED_WITH_TREEMERGE
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_replay_unpack_directories():
+def test_replay_unpack_directories(usual_setup_usual_teardown):
     create_pack_and_unpack_scenario()
 
     # Do a run with -D and pack it later during --replay.

--- a/tests/test_options/test_size.py
+++ b/tests/test_options/test_size.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 
 
@@ -11,8 +10,7 @@ def create_set():
         create_file('x' * 512, 'small' + suffix)
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_valid():
+def test_valid(usual_setup_usual_teardown):
     create_set()
 
     # Scalar:
@@ -50,8 +48,8 @@ def test_valid():
     *_, footer = run_rmlint('--size 1-18446744073709549K')
     assert footer['duplicates'] == 6
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_invalid():
+
+def test_invalid(usual_setup_usual_teardown):
     create_set()
 
     def trigger(*args):
@@ -83,8 +81,7 @@ def test_invalid():
 
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_replay_size():
+def test_replay_size(usual_setup_usual_teardown):
     create_file('', 'empty1')
     create_file('', 'empty2')
     create_file('xxx', 'a/xxx')

--- a/tests/test_options/test_sorting.py
+++ b/tests/test_options/test_sorting.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
-# encoding: utf-8
-from nose import with_setup
-from nose.plugins.attrib import attr
-from tests.utils import *
-
+import pytest
 from itertools import permutations, combinations
+
+from tests.utils import *
 
 
 PATHS = ['b_dir/', 'a_dir/', 'c_dir/']
@@ -53,9 +51,8 @@ def validate_order(data, tests):
             assert False
 
 
-@attr('slow')
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_sorting():
+@pytest.mark.slow
+def test_sorting(usual_setup_usual_teardown):
     # create some dupes with different PATHS, names and mtimes:
     create_file('xxx', PATHS[1] + 'a', mtime='2004-02-29  16:21:42.4')
     create_file('xxx', PATHS[0] + 'c', mtime='2004-02-29  16:21:42.6')
@@ -88,8 +85,7 @@ def test_sorting():
 
         validate_order(data, combo)
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_sort_by_outlyer():
+def test_sort_by_outlyer(usual_setup_usual_teardown):
     create_file('xxx', 'a/foo')
     create_file('xxx', 'b/foo')
 
@@ -110,8 +106,7 @@ def test_sort_by_outlyer():
 # https://github.com/sahib/rmlint/issues/196
 #
 # Testsetup by "Awerick"
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_sort_by_outlyer_hardcore():
+def test_sort_by_outlyer_hardcore(usual_setup_usual_teardown):
     for suffix in 'ABCD':
         create_file('xxx', 'inside/foo' + suffix)
 
@@ -152,8 +147,7 @@ def test_sort_by_outlyer_hardcore():
 
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_sort_by_regex():
+def test_sort_by_regex(usual_setup_usual_teardown):
     create_file('xxx', 'aaaa')
     create_file('xxx', 'aaab')
     create_file('xxx', 'b')
@@ -173,8 +167,7 @@ def test_sort_by_regex():
     assert paths[5].endswith('c')
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_sort_by_regex_bad_input():
+def test_sort_by_regex_bad_input(usual_setup_usual_teardown):
     create_file('xxx', 'aaaa')
     create_file('xxx', 'aaab')
 
@@ -204,8 +197,7 @@ def test_sort_by_regex_bad_input():
 
 
 # regression test for GitHub issue #484
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_regex_multiple_matches():
+def test_regex_multiple_matches(usual_setup_usual_teardown):
     paths = [os.path.join(dname, bname)
              for dname in ['unique_1', 'unique_2']
              for bname in ['a', 'a2', 'b']]

--- a/tests/test_options/test_stdin.py
+++ b/tests/test_options/test_stdin.py
@@ -1,16 +1,14 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 from subprocess import STDOUT, check_output
-from parameterized import parameterized
 
 import json
 import os
 
+import pytest
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_stdin_read():
+def test_stdin_read(usual_setup_usual_teardown):
     path_a = create_file('1234', 'a') + '\n'
     path_b = create_file('1234', 'b') + '\n'
     path_c = create_file('1234', '.hidden') + '\n'
@@ -33,8 +31,7 @@ def test_stdin_read():
     assert data[3]['path'].endswith('c')
     assert footer['total_lint_size'] == 12
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_stdin_read_newlines():
+def test_stdin_read_newlines(usual_setup_usual_teardown):
     path_a = create_file('1234', 'a') + '\0'
     path_b = create_file('1234', 'name\nwith\nnewlines') + '\0'
     path_c = create_file('1234', '.hidden') + '\0'
@@ -57,8 +54,7 @@ def test_stdin_read_newlines():
     assert data[3]['path'].endswith('newlines')
     assert footer['total_lint_size'] == 12
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_path_starting_with_dash():
+def test_path_starting_with_dash(usual_setup_usual_teardown):
     subdir = '-look-in-here'
     create_file('1234', subdir + '/a')
     create_file('1234', subdir + '/b')
@@ -83,9 +79,8 @@ def test_path_starting_with_dash():
 # Regression test for https://github.com/sahib/rmlint/issues/400
 # Do not search in current directory when piped empty input.
 # Also, treemerge should not fail if given zero paths.
-@parameterized([('-',), ('-0',), ('-D', '-')])
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_stdin_empty(*opts):
+@pytest.mark.parametrize("opts", (('-',), ('-0',), ('-D', '-')))
+def test_stdin_empty(usual_setup_usual_teardown, opts):
     create_file('1234', 'a')
     create_file('1234', 'b')
 

--- a/tests/test_options/test_symlinks.py
+++ b/tests/test_options/test_symlinks.py
@@ -1,14 +1,10 @@
 #!/usr/bin/env python3
-# encoding: utf-8
-
 import os
 
-from nose import with_setup
 from tests.utils import *
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_default():
+def test_default(usual_setup_usual_teardown):
     # --see-symlinks should be on by default.
     create_file('xxx', 'a/z')
     create_link('a/z', 'a/x', symlink=True)
@@ -24,8 +20,7 @@ def test_default():
         '/a/z',
     }
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_merge_directories_with_ignored_symlinks():
+def test_merge_directories_with_ignored_symlinks(usual_setup_usual_teardown):
     # Badlinks should not forbid finding duplicate directories
     # when being filtered out during traversing with -T dd,df.
     create_file('xxx', 'a/z')
@@ -39,8 +34,7 @@ def test_merge_directories_with_ignored_symlinks():
         '/b',
     }
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_order():
+def test_order(usual_setup_usual_teardown):
     create_file('xxx', 'a/z')
     create_link('a/z', 'a/x', symlink=True)
     create_file('xxx', 'b/z')
@@ -83,8 +77,7 @@ def test_order():
     assert data[file_idx + 1]['path'].endswith('z')
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_symlink_matches_file():
+def test_symlink_matches_file(usual_setup_usual_teardown):
     create_file('xxx', 'foo')
     create_file('foo', 'file')
     os.symlink('foo', os.path.join(TESTDIR_NAME, 'link'))

--- a/tests/test_robustness/test_8Mlongpathfiles.py
+++ b/tests/test_robustness/test_8Mlongpathfiles.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose.plugins.attrib import attr
-from nose import with_setup
+import pytest
 from tests.utils import *
 import sys
 
@@ -25,9 +24,8 @@ def branch_tree(current_path, remaining_depth):
             create_link(current_path + 'b' + str(i).zfill(7), current_path + 'h' + str(i).zfill(7))
 
 
-@attr('slow')
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_manylongpathfiles():
+@pytest.mark.slow
+def test_manylongpathfiles(usual_setup_usual_teardown):
     max_depth = 10 # will give 8M files total if NUMPAIRS = 1024+1
     branch_tree ("", max_depth)
 

--- a/tests/test_robustness/test_badlinks_as_args.py
+++ b/tests/test_robustness/test_badlinks_as_args.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 
 
 # Regression test for directly passing broken symbolic links
 # to the command line. See https://github.com/sahib/rmlint/pull/444
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_bad_symlinks_as_direct_args():
+def test_bad_symlinks_as_direct_args(usual_setup_usual_teardown):
     create_file('xxx', 'a')
     create_file('xxx', 'b')
 

--- a/tests/test_robustness/test_bigfiles.py
+++ b/tests/test_robustness/test_bigfiles.py
@@ -1,11 +1,7 @@
 #!/usr/bin/env python3
-# encoding: utf-8
-
 import os
 import subprocess
 
-from nose import with_setup
-from nose.plugins.attrib import attr
 from tests.utils import *
 
 FILE_SIZE_KB = 10000
@@ -15,8 +11,7 @@ KBYTES_FROM_END = 10
 LARGE_FILE_SIZE = 5 * 1024**3  # 5 GiB
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_bigfiles():
+def test_bigfiles(usual_setup_usual_teardown):
 
     num_bytes = int(FILE_SIZE_KB * 1024)
     # create two identical files and a third one which differs near the end:
@@ -59,8 +54,7 @@ def _setup_large_file_offset():
     return path_a, path_b, path_c
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_hash_utility():
+def test_hash_utility(usual_setup_usual_teardown):
     path_a, path_b, path_c = _setup_large_file_offset()
 
     # only files 'b' and 'c' should match

--- a/tests/test_robustness/test_collisions.py
+++ b/tests/test_robustness/test_collisions.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose.plugins.attrib import attr
-from nose import with_setup
+import pytest
 from tests.utils import *
 
 
@@ -11,9 +10,8 @@ from tests.utils import *
 # which degenerates into an inefficient O(n^2) lookup with large size groups
 BLACKLIST = ['paranoid']
 
-@attr('slow')
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_collision_resistance():
+@pytest.mark.slow
+def test_collision_resistance(usual_setup_usual_teardown):
     # test for at least 20 bits of collision resistancel
     # this should detect gross errors in checksum encoding...
 

--- a/tests/test_robustness/test_manyfiles.py
+++ b/tests/test_robustness/test_manyfiles.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose.plugins.attrib import attr
-from nose import with_setup
+import pytest
 from tests.utils import *
 
-@attr('slow')
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_manyfiles():
+@pytest.mark.slow
+def test_manyfiles(usual_setup_usual_teardown):
 
     # create heaps of identical files:
     numfiles = 1024 * 32 + 1

--- a/tests/test_robustness/test_manylongpathfiles.py
+++ b/tests/test_robustness/test_manylongpathfiles.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose.plugins.attrib import attr
-from nose import with_setup
+import pytest
 from tests.utils import *
 
-@attr('slow')
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_manylongpathfiles():
+@pytest.mark.slow
+def test_manylongpathfiles(usual_setup_usual_teardown):
 
 	#create ~1000 character path, 4 dirs deep
     longpath = ("long" * (1000//4//4) + "/") * 4

--- a/tests/test_robustness/test_path_doubles.py
+++ b/tests/test_robustness/test_path_doubles.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_cmdline():
+def test_cmdline(usual_setup_usual_teardown):
     create_file('xxx', '1/a')
     # feed rmlint the same file twice via command line
     head, *data, footer = run_rmlint('{t}/1 {t}/1'.format(t=TESTDIR_NAME), use_default_dir=False)
@@ -18,8 +16,7 @@ def test_cmdline():
     assert 0 == sum(find['type'] == 'duplicate_file' for find in data)
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_symlink_noloop():
+def test_symlink_noloop(usual_setup_usual_teardown):
     create_file('xxx', '1/a')
     create_link('1/a', '1/link', symlink=True)
 
@@ -35,8 +32,7 @@ def test_symlink_noloop():
     head, *data, footer = run_rmlint('{t}/1/a {t}/1/link'.format(t=TESTDIR_NAME), use_default_dir=False)
     assert 0 == sum(find['type'] == 'duplicate_file' for find in data)
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_symlink_loop():
+def test_symlink_loop(usual_setup_usual_teardown):
     create_file('xxx', '1/a')
     create_link('1', '1/link', symlink=True)
 
@@ -47,19 +43,7 @@ def test_symlink_loop():
     assert 0 == sum(find['type'] == 'duplicate_file' for find in data)
 
 
-def mount_bind_teardown_func():
-    if runs_as_root():
-        subprocess.call(
-            'umount {dst}'.format(
-                dst=os.path.join(TESTDIR_NAME, 'a/b')
-            ),
-            shell=True
-        )
-
-    usual_teardown_func()
-
-@with_setup(usual_setup_func, mount_bind_teardown_func)
-def test_mount_binds():
+def test_mount_binds(usual_setup_mount_bind_teardown):
     if not runs_as_root():
         return
 

--- a/tests/test_types/test_badlink.py
+++ b/tests/test_types/test_badlink.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 import os
 
@@ -17,8 +16,7 @@ def create_bad_link(link_name):
         os.remove(fake_target)
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_basic():
+def test_basic(usual_setup_usual_teardown):
     create_bad_link('imbad')
 
     for option in ('-f', '-F', '--see-symlinks'):

--- a/tests/test_types/test_baduids.py
+++ b/tests/test_types/test_baduids.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 
 import subprocess
@@ -24,8 +23,7 @@ def exec_cmds(cmds):
             print(cmd, 'failed:', err)
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_bad_ids():
+def test_bad_ids(usual_setup_usual_teardown):
     if not runs_as_root():
         return
 

--- a/tests/test_types/test_duplicate.py
+++ b/tests/test_types/test_duplicate.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 import os
 
@@ -13,8 +12,7 @@ def create_data(len, flips=None):
     return ''.join(data)
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_small_diffs():
+def test_small_diffs(usual_setup_usual_teardown):
 
     if use_valgrind():
         N = 32
@@ -51,8 +49,7 @@ def test_small_diffs():
             assert len(data) == 0
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_one_byte_file_negative():
+def test_one_byte_file_negative(usual_setup_usual_teardown):
     create_file('1', 'one')
     create_file('2', 'two')
     head, *data, footer = run_rmlint('-S a')
@@ -60,16 +57,14 @@ def test_one_byte_file_negative():
     assert len(data) == 0
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_one_byte_file_positive():
+def test_one_byte_file_positive(usual_setup_usual_teardown):
     create_file('1', 'one')
     create_file('1', 'two')
     head, *data, footer = run_rmlint('-S a')
 
     assert len(data) == 2
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_two_hardlinks():
+def test_two_hardlinks(usual_setup_usual_teardown):
     create_file('xxx', 'a')
     create_link('a', 'b')
     head, *data, footer = run_rmlint('-S a')
@@ -77,8 +72,7 @@ def test_two_hardlinks():
     assert len(data) == 2
     assert footer['total_lint_size'] == 0
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_two_external_hardlinks():
+def test_two_external_hardlinks(usual_setup_usual_teardown):
     create_file('xxx', 'a')
     create_file('xxx', 'b')
     create_dirs('sub')

--- a/tests/test_types/test_empty_dirs.py
+++ b/tests/test_types/test_empty_dirs.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 
-
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_simple():
+def test_simple(usual_setup_usual_teardown):
     create_file('xxx', 'not_empty/a')
     create_file('', 'empty_but_with_file/a')
     create_dirs('really_empty')
@@ -21,8 +18,7 @@ def test_simple():
     assert data[1]['type'] == "emptyfile"
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_deep():
+def test_deep(usual_setup_usual_teardown):
     create_dirs('1/2/3/4/5')
     head, *data, footer = run_rmlint('-T "none +ed"')
 
@@ -39,8 +35,7 @@ def test_deep():
     assert data[1]['path'].endswith('4')
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_hidden():
+def test_hidden(usual_setup_usual_teardown):
     create_file('xxx', 'not_empty/.hidden')
     head, *data, footer = run_rmlint('-T "none +ed"')
 

--- a/tests/test_types/test_empty_files.py
+++ b/tests/test_types/test_empty_files.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-from nose import with_setup
 from tests.utils import *
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_simple():
+def test_simple(usual_setup_usual_teardown):
     create_file('xxx', 'not_empty')
     create_file('', 'very_empty')
     head, *data, footer = run_rmlint('-T "none +ef"')

--- a/tests/test_types/test_nonstripped.py
+++ b/tests/test_types/test_nonstripped.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python3
-# encoding: utf-8
-
 import os
 
-from nose import with_setup
-from nose.plugins.skip import SkipTest
 from tests.utils import *
 
 SOURCE = '''
@@ -29,8 +25,7 @@ def create_binary(path, stripped=False):
     subprocess.run(command, input=SOURCE, shell=True, universal_newlines=True, check=True)
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_negative():
+def test_negative(usual_setup_usual_teardown):
     if has_feature('nonstripped') is False:
         return
 
@@ -42,8 +37,7 @@ def test_negative():
     assert len(data) == 0
 
 
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_positive():
+def test_positive(usual_setup_usual_teardown):
     if has_feature('nonstripped') is False:
         return
 
@@ -56,10 +50,9 @@ def test_positive():
 
 
 # regression test for GitHub issue #555
-@with_setup(usual_setup_func, usual_teardown_func)
-def test_executable_fifo():
+def test_executable_fifo(usual_setup_usual_teardown):
     if has_feature('nonstripped') is False:
-        raise SkipTest("needs 'nonstripped' feature")
+        pytest.skip("needs 'nonstripped' feature")
 
     fifo_path = os.path.join(TESTDIR_NAME, 'fifo')
     os.mkfifo(fifo_path)


### PR DESCRIPTION
Hi,
nose is no longer maintained, see
https://github.com/nose-devs/nose/issues/1099#issuecomment-562394879.

This bug was initially submitted here: https://bugs.gentoo.org/878695.

This commit switches to pytest.

Amongst the changes, here are the most relevant ones:
* Create a conftest.py that contains fixtures.
* Replace nose.with_setup with yield fixtures.
* Use pytest.skip instead of print and nose.plugins.skip.SkipTest.
* Use pytest.mark.slow instead of nose.plugins.attrib.attr("slow").
* Use pytest.mark.parametrize instead of parameterized, simplify parametrized tests that use both `shell` and `inverse_order`.
* Update Travis config.
* Update SConscript.
* Update documentation.