### PR TITLE
Fix --hash-unmatched behavior

### DIFF
--- a/lib/shredder.c
+++ b/lib/shredder.c
@@ -855,7 +855,7 @@ static void rm_shred_group_update_status(RmShredGroup *group) {
     } else if(group->n_clusters > 1) {
         // we have potential match candidates; start hashing
         group->status = RM_SHRED_GROUP_START_HASHING;
-    } else if(group->n_inodes == 1 && group->n_unhashed_clusters > 0 &&
+    } else if(group->num_files > 1 && group->n_unhashed_clusters > 0 &&
               group->session->cfg->merge_directories) {
         /* special case of hardlinked files that still need hashing to help identify
          * matching directories */

--- a/lib/shredder.c
+++ b/lib/shredder.c
@@ -860,12 +860,9 @@ static void rm_shred_group_update_status(RmShredGroup *group) {
         /* special case of hardlinked files that still need hashing to help identify
          * matching directories */
         group->status = RM_SHRED_GROUP_START_HASHING;
-    } else if(group->session->cfg->hash_unmatched && group->held_files->length > 0) {
-        RmFile *head = group->held_files->head->data;
-        if(head->digest) {
-            // with hash_unmatched, keep going once we start
-            group->status = RM_SHRED_GROUP_START_HASHING;
-        }
+    } else if(group->session->cfg->hash_unmatched && group->digest) {
+        // with hash_unmatched, keep going once we start
+        group->status = RM_SHRED_GROUP_START_HASHING;
     }
 }
 


### PR DESCRIPTION
The problem with `--hash-unmatched` is twofold.

First, the criterion in `rm_shred_group_update_status()` that is responsible for hashing partially-hashed groups to the end is broken. It can never be fulfilled because `group->head_files` is always empty at this point, and even if it was not, `head->digest` is always NULL because that's what `rm_shred_group_push_file()` does.

The only reason why `--hash-unmatched` even works is because the `--merge-directories` condition above is broken as well and it always fires for all single-file groups. (Consequently, `--hash-unmatched` without `--merge-directories` is broken in develop.) However, the same bug also means that all unique files will always get hashed to the end if `--merge-directories` is set, thus making `--hash-unmatched` behave like `--hash-uniques`.

This function only works as designed if neither `--hash-unmatched` nor `--hash-uniques` is set, because in this case all single-file groups get filtered early by the `rm_shred_group_qualifies()` check.

Fixes #614.