### PR TITLE
Add 'match-dirname' option

### DIFF
--- a/docs/rmlint.1.rst
+++ b/docs/rmlint.1.rst
@@ -386,6 +386,12 @@ Traversal Options
     extension. For example: ``banana.png`` and ``Banana.jpeg`` would be considered dupes,
     while ``apple.png`` and ``peach.png`` won't. The comparison is case-sensitive.
 
+:``--match-dirname``:
+
+    Only consider files as dupes whose parent directory have the same name (not the whole path,
+    only the parent). The comparison of every component is case-sensitive, unless
+    ``--case-insensitive`` is set.
+
 :``--match-relative-path``:
 
     Only consider files as dupes that have the same path, including the filename, relative

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -78,11 +78,11 @@ typedef struct RmCfg {
     gboolean filter_mtime;
     gboolean case_insensitive;
     gboolean match_basename;
-    gboolean match_dirname;
-    gboolean match_relative_path;
     gboolean unmatched_basenames;
     gboolean match_with_extension;
     gboolean match_without_extension;
+    gboolean match_dirname;
+    gboolean match_relative_path;
     gboolean merge_directories;
     gboolean honour_dir_layout;
     gboolean write_cksum_to_xattr;

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -78,6 +78,7 @@ typedef struct RmCfg {
     gboolean filter_mtime;
     gboolean case_insensitive;
     gboolean match_basename;
+    gboolean match_dirname;
     gboolean match_relative_path;
     gboolean unmatched_basenames;
     gboolean match_with_extension;

--- a/lib/cmdline.c
+++ b/lib/cmdline.c
@@ -1182,7 +1182,7 @@ bool rm_cmd_parse_args(int argc, char **argv, RmSession *session) {
         {"must-match-tagged"        , 'm'  , 0         , G_OPTION_ARG_NONE      , &cfg->must_match_tagged        , _("Must have twin in tagged dir")                                         , NULL}     ,
         {"must-match-untagged"      , 'M'  , 0         , G_OPTION_ARG_NONE      , &cfg->must_match_untagged      , _("Must have twin in untagged dir")                                       , NULL}     ,
         {"match-basename"           , 'b'  , 0         , G_OPTION_ARG_NONE      , &cfg->match_basename           , _("Only find twins with same basename")                                   , NULL}     ,
-        {"match-dirname"            , 'B'  , 0         , G_OPTION_ARG_NONE      , &cfg->match_dirname            , _("Only find twins with same dirname")                                    , NULL}     ,
+        {"match-dirname"            , 0    , 0         , G_OPTION_ARG_NONE      , &cfg->match_dirname            , _("Only find twins with same dirname")                                    , NULL}     ,
         {"match-extension"          , 'e'  , 0         , G_OPTION_ARG_NONE      , &cfg->match_with_extension     , _("Only find twins with same extension")                                  , NULL}     ,
         {"match-relative-path"      , 0    , HIDDEN    , G_OPTION_ARG_NONE      , &cfg->match_relative_path      , _("Only find twins with same relative path")                              , NULL}     ,
         {"match-without-extension"  , 'i'  , 0         , G_OPTION_ARG_NONE      , &cfg->match_without_extension  , _("Only find twins with same basename minus extension")                   , NULL}     ,

--- a/lib/cmdline.c
+++ b/lib/cmdline.c
@@ -1182,6 +1182,7 @@ bool rm_cmd_parse_args(int argc, char **argv, RmSession *session) {
         {"must-match-tagged"        , 'm'  , 0         , G_OPTION_ARG_NONE      , &cfg->must_match_tagged        , _("Must have twin in tagged dir")                                         , NULL}     ,
         {"must-match-untagged"      , 'M'  , 0         , G_OPTION_ARG_NONE      , &cfg->must_match_untagged      , _("Must have twin in untagged dir")                                       , NULL}     ,
         {"match-basename"           , 'b'  , 0         , G_OPTION_ARG_NONE      , &cfg->match_basename           , _("Only find twins with same basename")                                   , NULL}     ,
+        {"match-dirname"            , 'B'  , 0         , G_OPTION_ARG_NONE      , &cfg->match_dirname            , _("Only find twins with same dirname")                                    , NULL}     ,
         {"match-extension"          , 'e'  , 0         , G_OPTION_ARG_NONE      , &cfg->match_with_extension     , _("Only find twins with same extension")                                  , NULL}     ,
         {"match-relative-path"      , 0    , HIDDEN    , G_OPTION_ARG_NONE      , &cfg->match_relative_path      , _("Only find twins with same relative path")                              , NULL}     ,
         {"match-without-extension"  , 'i'  , 0         , G_OPTION_ARG_NONE      , &cfg->match_without_extension  , _("Only find twins with same basename minus extension")                   , NULL}     ,

--- a/lib/cmdline.c
+++ b/lib/cmdline.c
@@ -1182,7 +1182,7 @@ bool rm_cmd_parse_args(int argc, char **argv, RmSession *session) {
         {"must-match-tagged"        , 'm'  , 0         , G_OPTION_ARG_NONE      , &cfg->must_match_tagged        , _("Must have twin in tagged dir")                                         , NULL}     ,
         {"must-match-untagged"      , 'M'  , 0         , G_OPTION_ARG_NONE      , &cfg->must_match_untagged      , _("Must have twin in untagged dir")                                       , NULL}     ,
         {"match-basename"           , 'b'  , 0         , G_OPTION_ARG_NONE      , &cfg->match_basename           , _("Only find twins with same basename")                                   , NULL}     ,
-        {"match-dirname"            , 0    , 0         , G_OPTION_ARG_NONE      , &cfg->match_dirname            , _("Only find twins with same dirname")                                    , NULL}     ,
+        {"match-dirname"            , 0    , HIDDEN    , G_OPTION_ARG_NONE      , &cfg->match_dirname            , _("Only find twins with same dirname")                                    , NULL}     ,
         {"match-extension"          , 'e'  , 0         , G_OPTION_ARG_NONE      , &cfg->match_with_extension     , _("Only find twins with same extension")                                  , NULL}     ,
         {"match-relative-path"      , 0    , HIDDEN    , G_OPTION_ARG_NONE      , &cfg->match_relative_path      , _("Only find twins with same relative path")                              , NULL}     ,
         {"match-without-extension"  , 'i'  , 0         , G_OPTION_ARG_NONE      , &cfg->match_without_extension  , _("Only find twins with same basename minus extension")                   , NULL}     ,

--- a/lib/rank.c
+++ b/lib/rank.c
@@ -217,12 +217,14 @@ gint rm_rank_without_extension(const RmFile *file_a, const RmFile *file_b, bool 
     return rm_match_strncmp(basename_a, basename_b, a_len, ignore_case);
 }
 
-gint rm_rank_dirname(const RmFile *file_a, const RmFile *file_b, bool ignore_case) {
-    if (!file_a->node->parent || !file_b->node->parent)
+static gint rm_rank_dirname(const RmFile *file_a, const RmFile *file_b, bool ignore_case) {
+    const RmNode *const parent_a = file_a->node->parent;
+    const RmNode *const parent_b = file_b->node->parent;
+
+    if (!parent_a || !parent_b)
         return 0;
 
-    return rm_match_strcmp(file_a->node->parent->basename, file_b->node->parent->basename,
-                           ignore_case);
+    return rm_match_strcmp(parent_a->basename, parent_b->basename, ignore_case);
 }
 
 

--- a/lib/rank.c
+++ b/lib/rank.c
@@ -217,6 +217,14 @@ gint rm_rank_without_extension(const RmFile *file_a, const RmFile *file_b, bool 
     return rm_match_strncmp(basename_a, basename_b, a_len, ignore_case);
 }
 
+gint rm_rank_dirname(const RmFile *file_a, const RmFile *file_b, bool ignore_case) {
+    if (!file_a->node->parent || !file_b->node->parent)
+        return 0;
+
+    return rm_match_strcmp(file_a->node->parent->basename, file_b->node->parent->basename,
+                           ignore_case);
+}
+
 
 /* Sort criteria for sorting by preferred path (first) then user-input criteria */
 /* Return:
@@ -276,6 +284,11 @@ gint rm_rank_group(const RmFile *file_a, const RmFile *file_b) {
 
     if (cfg->match_without_extension) {
         rank = rm_rank_without_extension(file_a, file_b, cfg->case_insensitive);
+        RETURN_IF_NONZERO(rank)
+    }
+
+    if (cfg->match_dirname) {
+        rank = rm_rank_dirname(file_a, file_b, cfg->case_insensitive);
         RETURN_IF_NONZERO(rank)
     }
 

--- a/lib/rank.h
+++ b/lib/rank.h
@@ -44,8 +44,6 @@ gint rm_rank_without_extension(const RmFile *file_a, const RmFile *file_b, bool 
  */
 gint rm_rank_relative_path(const RmFile *file_a, const RmFile *file_b, bool ignore_case);
 
-gint rm_rank_dirname(const RmFile *file_a, const RmFile *file_b, bool);
-
 /**
  * @brief Compare two files in order to find out which file is the
  * higher ranked (ie original).

--- a/lib/rank.h
+++ b/lib/rank.h
@@ -44,6 +44,8 @@ gint rm_rank_without_extension(const RmFile *file_a, const RmFile *file_b, bool 
  */
 gint rm_rank_relative_path(const RmFile *file_a, const RmFile *file_b, bool ignore_case);
 
+gint rm_rank_dirname(const RmFile *file_a, const RmFile *file_b, bool);
+
 /**
  * @brief Compare two files in order to find out which file is the
  * higher ranked (ie original).

--- a/tests/test_options/test_match_basenames.py
+++ b/tests/test_options/test_match_basenames.py
@@ -1,6 +1,6 @@
 import os
 
-from tests.utils import create_file, run_rmlint, get_testdir
+from tests.utils import create_file, get_testdir, run_rmlint
 
 
 def test_negative_with_basename():

--- a/tests/test_options/test_match_dirname.py
+++ b/tests/test_options/test_match_dirname.py
@@ -1,0 +1,23 @@
+from tests.utils import create_file, get_testdir, run_rmlint
+
+
+def test_matched():
+    create_file('xxx', 'a/path/file')
+    create_file('xxx', 'b/another/path/file')
+
+    _, *_, footer = run_rmlint(
+        '--match-dirname a b', use_default_dir=False)
+
+    assert footer['total_files'] == 2
+    assert footer['duplicates'] == 1
+
+
+def test_not_matched():
+    create_file('xxx', 'a/path/file')
+    create_file('xxx', 'b/path/another/file')
+
+    _, *_, footer = run_rmlint(
+        '--match-dirname a b', use_default_dir=False)
+
+    assert footer['total_files'] == 2
+    assert footer['duplicates'] == 0

--- a/tests/test_options/test_match_relative_path.py
+++ b/tests/test_options/test_match_relative_path.py
@@ -1,6 +1,6 @@
 import os
 
-from tests.utils import create_file, run_rmlint, get_testdir
+from tests.utils import create_file, get_testdir, run_rmlint
 
 
 def search_paths(*roots):


### PR DESCRIPTION
Not sure if you would be interested in this. I wanted to run rmlint but only compare files among the same directory, that is, allowing duplicate files to exist in different directories.

Although this option only checks the name of the parent folder only (not the whole path in its entirety) it achieves what I needed.