### PR TITLE
Update .version

### DIFF
--- a/.version
+++ b/.version
@@ -1,1 +1,1 @@
-2.10.1 Ludicrous Lemur
+2.10.2


### PR DESCRIPTION
DEPRECATION: shredder 2.10.1.Ludicrous.Lemur has a non-standard version number. pip 23.3 will enforce this behaviour change. A possible replacement is to upgrade to a newer version of shredder or contact the author to suggest that they release a version with a conforming version number. Discussion can be found at https://github.com/pypa/pip/issues/12063