### PR TITLE
Add "quotes" to $RMLINT_BINARY in clone() function

### DIFF
--- a/lib/formats/sh.sh
+++ b/lib/formats/sh.sh
@@ -225,9 +225,9 @@ clone() {
     echo "${COL_YELLOW}Cloning to: ${COL_RESET}$1"
     if [ -z "$DO_DRY_RUN" ]; then
         if [ -n "$DO_CLONE_READONLY" ]; then
-            $SUDO_COMMAND $RMLINT_BINARY --dedupe %s --dedupe-readonly "$2" "$1"
+            $SUDO_COMMAND "$RMLINT_BINARY" --dedupe %s --dedupe-readonly "$2" "$1"
         else
-            $RMLINT_BINARY --dedupe %s "$2" "$1"
+            "$RMLINT_BINARY" --dedupe %s "$2" "$1"
         fi
     fi
 }


### PR DESCRIPTION
To correct ShellCheck SC2086 (Double quote to prevent globbing and word splitting) in generated rmlint.sh.