### PR TITLE
Added --match-relative-path option and support

### DIFF
--- a/docs/rmlint.1.rst
+++ b/docs/rmlint.1.rst
@@ -386,6 +386,12 @@ Traversal Options
     extension. For example: ``banana.png`` and ``Banana.jpeg`` would be considered dupes,
     while ``apple.png`` and ``peach.png`` won't. The comparison is case-sensitive.
 
+:``--match-relative-path``:
+
+    Only consider files as dupes that have the same path, including the filename, relative
+    to the given path. The comparison of every component is case-sensitive, unless
+    ``--case-insensitive`` is set.
+
 :``--case-insensitive``:
 
     Make the ``--match-`` options above become case-insensitive for ASCII characters

--- a/docs/rmlint.1.rst
+++ b/docs/rmlint.1.rst
@@ -363,27 +363,33 @@ Traversal Options
     they're inside duplicate directories (see ``--merge-directories``) and will
     be deleted as part of it.
 
-:``-b --match-basename``:
-
-    Only consider those files as dupes that have the same basename. See also
-    ``man 1 basename``. The comparison of the basenames is case-insensitive.
-
 :``-B --unmatched-basename``:
 
     Only consider those files as dupes that do not share the same basename.
-    See also ``man 1 basename``. The comparison of the basenames is case-insensitive.
+    See also ``man 1 basename``. The comparison is basenames case-insensitive.
+
+:``-b --match-basename``:
+
+    Only consider those files as dupes that have the same basename. See also
+    ``man 1 basename``. The comparison of the basenames is case-sensitive.
 
 :``-e --match-extension`` / ``-E --no-match-extension`` (**default**):
 
     Only consider those files as dupes that have the same file extension. For
     example two photos would only match if they are a ``.png``. The extension is
-    compared case-insensitive, so ``.PNG`` is the same as ``.png``.
+    compared case-sensitive. Use with ``--case-insensitive`` so that ``.PNG`` and
+    ``.png`` are matching.
 
 :``-i --match-without-extension`` / ``-I --no-match-without-extension`` (**default**):
 
     Only consider those files as dupes that have the same basename minus the file
     extension. For example: ``banana.png`` and ``Banana.jpeg`` would be considered dupes,
-    while ``apple.png`` and ``peach.png`` won't. The comparison is case-insensitive.
+    while ``apple.png`` and ``peach.png`` won't. The comparison is case-sensitive.
+
+:``--case-insensitive``:
+
+    Make the ``--match-`` options above become case-insensitive for ASCII characters
+    (and only them, other characters still must match exactly).
 
 :``-n --newer-than-stamp=<timestamp_filename>`` / ``-N --newer-than=<iso8601_timestamp_or_unix_timestamp>``:
 

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -77,6 +77,7 @@ typedef struct RmCfg {
     gboolean apply_limits_to_dirs;
     gboolean filter_mtime;
     gboolean match_basename;
+    gboolean match_relative_path;
     gboolean unmatched_basenames;
     gboolean match_with_extension;
     gboolean match_without_extension;

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -76,6 +76,7 @@ typedef struct RmCfg {
     gboolean limits_specified;
     gboolean apply_limits_to_dirs;
     gboolean filter_mtime;
+    gboolean case_insensitive;
     gboolean match_basename;
     gboolean match_relative_path;
     gboolean unmatched_basenames;

--- a/lib/cmdline.c
+++ b/lib/cmdline.c
@@ -1186,6 +1186,7 @@ bool rm_cmd_parse_args(int argc, char **argv, RmSession *session) {
         {"must-match-untagged"      , 'M'  , 0         , G_OPTION_ARG_NONE      , &cfg->must_match_untagged      , _("Must have twin in untagged dir")                                       , NULL}     ,
         {"match-basename"           , 'b'  , 0         , G_OPTION_ARG_NONE      , &cfg->match_basename           , _("Only find twins with same basename")                                   , NULL}     ,
         {"match-extension"          , 'e'  , 0         , G_OPTION_ARG_NONE      , &cfg->match_with_extension     , _("Only find twins with same extension")                                  , NULL}     ,
+        {"match-relative-path"      , 0    , 0         , G_OPTION_ARG_NONE      , &cfg->match_relative_path      , _("Only find twins with same relative path")                              , NULL}     ,
         {"match-without-extension"  , 'i'  , 0         , G_OPTION_ARG_NONE      , &cfg->match_without_extension  , _("Only find twins with same basename minus extension")                   , NULL}     ,
         {"merge-directories"        , 'D'  , EMPTY     , G_OPTION_ARG_CALLBACK  , FUNC(merge_directories)        , _("Find duplicate directories")                                           , NULL}     ,
         {"honour-dir-layout"        , 'j'  , EMPTY     , G_OPTION_ARG_CALLBACK  , FUNC(honour_dir_layout)        , _("Only find directories with same file layout")                          , NULL}     ,

--- a/lib/cmdline.c
+++ b/lib/cmdline.c
@@ -1188,6 +1188,7 @@ bool rm_cmd_parse_args(int argc, char **argv, RmSession *session) {
         {"match-extension"          , 'e'  , 0         , G_OPTION_ARG_NONE      , &cfg->match_with_extension     , _("Only find twins with same extension")                                  , NULL}     ,
         {"match-relative-path"      , 0    , HIDDEN    , G_OPTION_ARG_NONE      , &cfg->match_relative_path      , _("Only find twins with same relative path")                              , NULL}     ,
         {"match-without-extension"  , 'i'  , 0         , G_OPTION_ARG_NONE      , &cfg->match_without_extension  , _("Only find twins with same basename minus extension")                   , NULL}     ,
+        {"case-insensitive"         , 0    , 0         , G_OPTION_ARG_NONE      , &cfg->case_insensitive         , _("--(un)match options are treated case-insensitively")                   , NULL}     ,
         {"merge-directories"        , 'D'  , EMPTY     , G_OPTION_ARG_CALLBACK  , FUNC(merge_directories)        , _("Find duplicate directories")                                           , NULL}     ,
         {"honour-dir-layout"        , 'j'  , EMPTY     , G_OPTION_ARG_CALLBACK  , FUNC(honour_dir_layout)        , _("Only find directories with same file layout")                          , NULL}     ,
         {"perms"                    , 'z'  , OPTIONAL  , G_OPTION_ARG_CALLBACK  , FUNC(permissions)              , _("Only use files with certain permissions")                              , "[RWX]+"} ,

--- a/lib/cmdline.c
+++ b/lib/cmdline.c
@@ -1186,7 +1186,7 @@ bool rm_cmd_parse_args(int argc, char **argv, RmSession *session) {
         {"must-match-untagged"      , 'M'  , 0         , G_OPTION_ARG_NONE      , &cfg->must_match_untagged      , _("Must have twin in untagged dir")                                       , NULL}     ,
         {"match-basename"           , 'b'  , 0         , G_OPTION_ARG_NONE      , &cfg->match_basename           , _("Only find twins with same basename")                                   , NULL}     ,
         {"match-extension"          , 'e'  , 0         , G_OPTION_ARG_NONE      , &cfg->match_with_extension     , _("Only find twins with same extension")                                  , NULL}     ,
-        {"match-relative-path"      , 0    , 0         , G_OPTION_ARG_NONE      , &cfg->match_relative_path      , _("Only find twins with same relative path")                              , NULL}     ,
+        {"match-relative-path"      , 0    , HIDDEN    , G_OPTION_ARG_NONE      , &cfg->match_relative_path      , _("Only find twins with same relative path")                              , NULL}     ,
         {"match-without-extension"  , 'i'  , 0         , G_OPTION_ARG_NONE      , &cfg->match_without_extension  , _("Only find twins with same basename minus extension")                   , NULL}     ,
         {"merge-directories"        , 'D'  , EMPTY     , G_OPTION_ARG_CALLBACK  , FUNC(merge_directories)        , _("Find duplicate directories")                                           , NULL}     ,
         {"honour-dir-layout"        , 'j'  , EMPTY     , G_OPTION_ARG_CALLBACK  , FUNC(honour_dir_layout)        , _("Only find directories with same file layout")                          , NULL}     ,

--- a/lib/rank.c
+++ b/lib/rank.c
@@ -168,8 +168,16 @@ static int rm_rank_criterion(unsigned char criterion, const RmFile *a, const RmF
 
 
 ///////////////////////////////
-//     API Implementatin     //
+//     API Implementation    //
 ///////////////////////////////
+
+static inline gint rm_match_strcmp(const gchar* s1, const gchar* s2, bool ignore_case) {
+    return ignore_case ? g_ascii_strcasecmp(s1, s2) : strcmp(s1, s2);
+}
+
+static inline gint rm_match_strncmp(const gchar* s1, const gchar* s2, gsize n, bool ignore_case) {
+    return ignore_case ? g_ascii_strncasecmp(s1, s2, n) : strncmp(s1, s2, n);
+}
 
 /*--------------------------------------------------------------------*/
 /*  --match-basename, --match-extension and --match-without-extension */
@@ -178,12 +186,12 @@ static int rm_rank_criterion(unsigned char criterion, const RmFile *a, const RmF
  * eg comparing "/path1/foo.c" vs "/path2/bar.c" should return 0 (both .c)
  * Used for --match-extension option.
  */
-gint rm_rank_with_extension(const RmFile *file_a, const RmFile *file_b) {
+gint rm_rank_with_extension(const RmFile *file_a, const RmFile *file_b, bool ignore_case) {
     const char *ext_a = rm_util_path_extension(file_a->node->basename);
     const char *ext_b = rm_util_path_extension(file_b->node->basename);
 
     if(ext_a && ext_b) {
-        return g_ascii_strcasecmp(ext_a, ext_b);
+        return rm_match_strcmp(ext_a, ext_b, ignore_case);
     } else {
         /* file with an extension outranks one without */
         return (!!ext_a - !!ext_b);
@@ -193,7 +201,7 @@ gint rm_rank_with_extension(const RmFile *file_a, const RmFile *file_b) {
 /* Compare func to sort two RmFiles in order of filename excluding extension,
  * eg comparing "/path1/foo.c" vs "/path2/foo.h" should return 0 (both foo)
  * Used for --match-without-extension option */
-gint rm_rank_without_extension(const RmFile *file_a, const RmFile *file_b) {
+gint rm_rank_without_extension(const RmFile *file_a, const RmFile *file_b, bool ignore_case) {
     const char *basename_a = file_a->node->basename;
     const char *basename_b = file_b->node->basename;
 
@@ -206,7 +214,7 @@ gint rm_rank_without_extension(const RmFile *file_a, const RmFile *file_b) {
 
     RETURN_IF_NONZERO(SIGN_DIFF(a_len, b_len));
 
-    return g_ascii_strncasecmp(basename_a, basename_b, a_len);
+    return rm_match_strncmp(basename_a, basename_b, a_len, ignore_case);
 }
 
 
@@ -251,14 +259,15 @@ gint rm_rank_group(const RmFile *file_a, const RmFile *file_b) {
     RETURN_IF_NONZERO(SIGN_DIFF(file_a->is_symlink, file_b->is_symlink));
 
     RmCfg *cfg = file_a->session->cfg;
+    bool ignore_case = file_a->session->cfg->case_insensitive;
 
-    RETURN_IF_NONZERO(cfg->match_basename && rm_rank_basenames(file_a, file_b));
+    RETURN_IF_NONZERO(cfg->match_basename && rm_rank_basenames(file_a, file_b, ignore_case));
 
-    RETURN_IF_NONZERO(cfg->match_relative_path && rm_rank_relative_path(file_a, file_b));
+    RETURN_IF_NONZERO(cfg->match_with_extension && rm_rank_with_extension(file_a, file_b, ignore_case));
 
-    RETURN_IF_NONZERO(cfg->match_with_extension && rm_rank_with_extension(file_a, file_b));
+    RETURN_IF_NONZERO(cfg->match_without_extension && rm_rank_without_extension(file_a, file_b, ignore_case));
 
-    return cfg->match_without_extension && rm_rank_without_extension(file_a, file_b);
+    return cfg->match_relative_path && rm_rank_relative_path(file_a, file_b, ignore_case);
 }
 
 /* GCompareDataFunc wrapper around rm_rank_group */
@@ -267,20 +276,18 @@ gint rm_rank_group_gcmp(gconstpointer file_a, gconstpointer file_b,
     return rm_rank_group(file_a, file_b);
 }
 
-
-
-gint rm_rank_basenames(const RmFile *file_a, const RmFile *file_b) {
-    return g_ascii_strcasecmp(file_a->node->basename, file_b->node->basename);
+gint rm_rank_basenames(const RmFile *file_a, const RmFile *file_b, bool ignore_case) {
+    return rm_match_strcmp(file_a->node->basename, file_b->node->basename, ignore_case);
 }
 
-gint rm_rank_relative_path(const RmFile *file_a, const RmFile *file_b) {
+gint rm_rank_relative_path(const RmFile *file_a, const RmFile *file_b, bool ignore_case) {
     gint diff = file_a->depth - file_b->depth;
     RETURN_IF_NONZERO(diff);
 
     /* a file named directly from arguments or stdin is of zero depth.
      * compare basenames like we would have if they were not top-level. */
     if (!file_a->depth)
-        return rm_rank_basenames(file_a, file_b);
+        return rm_rank_basenames(file_a, file_b, ignore_case);
 
     RmNode* node_a = file_a->node;
     RmNode* node_b = file_b->node;
@@ -289,7 +296,7 @@ gint rm_rank_relative_path(const RmFile *file_a, const RmFile *file_b) {
         g_assert(node_a);
         g_assert(node_b);
 
-        diff = g_ascii_strcasecmp(node_a->basename, node_b->basename);
+        diff = rm_match_strcmp(node_a->basename, node_b->basename, ignore_case);
         RETURN_IF_NONZERO(diff);
 
         node_a = node_a->parent;

--- a/lib/rank.c
+++ b/lib/rank.c
@@ -276,6 +276,12 @@ gint rm_rank_basenames(const RmFile *file_a, const RmFile *file_b) {
 gint rm_rank_relative_path(const RmFile *file_a, const RmFile *file_b) {
     gint diff = file_a->depth - file_b->depth;
     RETURN_IF_NONZERO(diff);
+
+    /* a file named directly from arguments or stdin is of zero depth.
+     * compare basenames like we would have if they were not top-level. */
+    if (!file_a->depth)
+        return rm_rank_basenames(file_a, file_b);
+
     RmNode* node_a = file_a->node;
     RmNode* node_b = file_b->node;
 

--- a/lib/rank.c
+++ b/lib/rank.c
@@ -253,21 +253,38 @@ int rm_rank_orig_criteria(const RmFile *a, const RmFile *b, const RmSession *ses
  * each other.  The sorted list can then be split into groups of potential
  * duplicates by splitting whereever rm_rank_group(a, b) != 0 */
 gint rm_rank_group(const RmFile *file_a, const RmFile *file_b) {
-    RETURN_IF_NONZERO(SIGN_DIFF(file_a->actual_file_size, file_b->actual_file_size));
+    gint rank;
+
+    rank = SIGN_DIFF(file_a->actual_file_size, file_b->actual_file_size);
+    RETURN_IF_NONZERO(rank)
 
     /* --see-symlinks should not let regular files match symlinks */
-    RETURN_IF_NONZERO(SIGN_DIFF(file_a->is_symlink, file_b->is_symlink));
+    rank = SIGN_DIFF(file_a->is_symlink, file_b->is_symlink);
+    RETURN_IF_NONZERO(rank)
 
     RmCfg *cfg = file_a->session->cfg;
-    bool ignore_case = file_a->session->cfg->case_insensitive;
 
-    RETURN_IF_NONZERO(cfg->match_basename && rm_rank_basenames(file_a, file_b, ignore_case));
+    if (cfg->match_basename) {
+        rank = rm_rank_basenames(file_a, file_b, cfg->case_insensitive);
+        RETURN_IF_NONZERO(rank)
+    }
 
-    RETURN_IF_NONZERO(cfg->match_with_extension && rm_rank_with_extension(file_a, file_b, ignore_case));
+    if (cfg->match_with_extension) {
+        rank = rm_rank_with_extension(file_a, file_b, cfg->case_insensitive);
+        RETURN_IF_NONZERO(rank)
+    }
 
-    RETURN_IF_NONZERO(cfg->match_without_extension && rm_rank_without_extension(file_a, file_b, ignore_case));
+    if (cfg->match_without_extension) {
+        rank = rm_rank_without_extension(file_a, file_b, cfg->case_insensitive);
+        RETURN_IF_NONZERO(rank)
+    }
 
-    return cfg->match_relative_path && rm_rank_relative_path(file_a, file_b, ignore_case);
+    if (cfg->match_relative_path) {
+        rank = rm_rank_relative_path(file_a, file_b, cfg->case_insensitive);
+        RETURN_IF_NONZERO(rank)
+    }
+
+    return 0;
 }
 
 /* GCompareDataFunc wrapper around rm_rank_group */

--- a/lib/rank.c
+++ b/lib/rank.c
@@ -254,6 +254,8 @@ gint rm_rank_group(const RmFile *file_a, const RmFile *file_b) {
 
     RETURN_IF_NONZERO(cfg->match_basename && rm_rank_basenames(file_a, file_b));
 
+    RETURN_IF_NONZERO(cfg->match_relative_path && rm_rank_relative_path(file_a, file_b));
+
     RETURN_IF_NONZERO(cfg->match_with_extension && rm_rank_with_extension(file_a, file_b));
 
     return cfg->match_without_extension && rm_rank_without_extension(file_a, file_b);
@@ -269,6 +271,25 @@ gint rm_rank_group_gcmp(gconstpointer file_a, gconstpointer file_b,
 
 gint rm_rank_basenames(const RmFile *file_a, const RmFile *file_b) {
     return g_ascii_strcasecmp(file_a->node->basename, file_b->node->basename);
+}
+
+gint rm_rank_relative_path(const RmFile *file_a, const RmFile *file_b) {
+    gint diff = file_a->depth - file_b->depth;
+    RETURN_IF_NONZERO(diff);
+    RmNode* node_a = file_a->node;
+    RmNode* node_b = file_b->node;
+
+    for (gint16 depth = file_a->depth; depth > 0; --depth) {
+        g_assert(node_a);
+        g_assert(node_b);
+
+        diff = g_ascii_strcasecmp(node_a->basename, node_b->basename);
+        RETURN_IF_NONZERO(diff);
+
+        node_a = node_a->parent;
+        node_b = node_b->parent;
+    }
+    return 0;
 }
 
 

--- a/lib/rank.h
+++ b/lib/rank.h
@@ -32,17 +32,17 @@
  * @brief Compare basenames of two files
  * @retval 0 if basenames match.
  */
-gint rm_rank_basenames(const RmFile *file_a, const RmFile *file_b);
+gint rm_rank_basenames(const RmFile *file_a, const RmFile *file_b, bool ignore_case);
 
-gint rm_rank_with_extension(const RmFile *file_a, const RmFile *file_b);
+gint rm_rank_with_extension(const RmFile *file_a, const RmFile *file_b, bool ignore_case);
 
-gint rm_rank_without_extension(const RmFile *file_a, const RmFile *file_b);
+gint rm_rank_without_extension(const RmFile *file_a, const RmFile *file_b, bool ignore_case);
 
 /**
  * @brief Compare relative paths of two files
  * @retval true if relative paths match.
  */
-gint rm_rank_relative_path(const RmFile *file_a, const RmFile *file_b);
+gint rm_rank_relative_path(const RmFile *file_a, const RmFile *file_b, bool ignore_case);
 
 /**
  * @brief Compare two files in order to find out which file is the

--- a/lib/rank.h
+++ b/lib/rank.h
@@ -39,6 +39,12 @@ gint rm_rank_with_extension(const RmFile *file_a, const RmFile *file_b);
 gint rm_rank_without_extension(const RmFile *file_a, const RmFile *file_b);
 
 /**
+ * @brief Compare relative paths of two files
+ * @retval true if relative paths match.
+ */
+gint rm_rank_relative_path(const RmFile *file_a, const RmFile *file_b);
+
+/**
  * @brief Compare two files in order to find out which file is the
  * higher ranked (ie original).
  *

--- a/lib/shredder.c
+++ b/lib/shredder.c
@@ -910,13 +910,12 @@ static RmFile *rm_shred_group_push_file(RmShredGroup *shred_group, RmFile *file,
             if(shred_group->num_files == 0) {
                 shred_group->unique_basename = file;
             } else if(shred_group->unique_basename &&
-                      rm_rank_basenames(file, shred_group->unique_basename) != 0) {
+                      rm_rank_basenames(file, shred_group->unique_basename, true) != 0) {
                 shred_group->unique_basename = NULL;
             }
             if(file->cluster) {
                 for(GList *iter = file->cluster->head; iter; iter = iter->next) {
-                    if(rm_rank_basenames(iter->data, shred_group->unique_basename) !=
-                       0) {
+                    if(rm_rank_basenames(iter->data, shred_group->unique_basename, true) != 0) {
                         shred_group->unique_basename = NULL;
                         break;
                     }
@@ -1419,7 +1418,7 @@ static RmShredGroup *rm_shred_basename_rejects(RmShredGroup *group, RmShredTag *
             iter = next) {
             next = iter->next;
             RmFile *curr = iter->data;
-            if(rm_rank_basenames(curr, headfile) == 0) {
+            if(rm_rank_basenames(curr, headfile, true) == 0) {
                 if(!rejects) {
                     rejects = rm_shred_create_rejects(group, curr);
                 }

--- a/tests/test_options/test_match_basenames.py
+++ b/tests/test_options/test_match_basenames.py
@@ -1,4 +1,6 @@
-from tests.utils import create_file, run_rmlint
+import os
+
+from tests.utils import create_file, run_rmlint, get_testdir
 
 
 def test_negative_with_basename():
@@ -35,3 +37,45 @@ def test_positive_without_basename():
     assert footer['total_files'] == 2
     assert footer['total_lint_size'] == 3
     assert footer['duplicates'] == 1
+
+
+TOTAL_FILES = 10
+def test_split():
+    """Identical files split into basenames a.txt and b.txt should give two equal groups."""
+
+    roots = []
+    for idx in range(TOTAL_FILES):
+        create_file('xxx', f'{idx}/{'a.ext' if idx % 2 == 0 else 'b.ext'}')
+        roots.append(os.path.join(get_testdir(), str(idx)))
+
+    _, *data, footer = run_rmlint(
+        '-b ' + ' '.join(roots), use_default_dir=False
+    )
+
+    assert footer['total_files'] == TOTAL_FILES
+
+    groups = []
+    for entry in data:
+        if entry['type'] != 'duplicate_file':
+            continue
+        if entry['is_original']:
+            groups.append(0)
+        groups[-1] += 1
+
+    assert groups == [TOTAL_FILES // 2] * 2
+    assert footer['duplicates'] == TOTAL_FILES - 2
+
+
+def test_one_group():
+    """If the basenames are all the same, we should get one group."""
+
+    roots = []
+    for idx in range(TOTAL_FILES):
+        create_file('xxx', f'{idx}/a.ext')
+        roots.append(os.path.join(get_testdir(), str(idx)))
+
+    _, *_, footer = run_rmlint(
+        '-b ' + ' '.join(roots), use_default_dir=False)
+
+    assert footer['total_files'] == TOTAL_FILES
+    assert footer['duplicates'] == TOTAL_FILES - 1

--- a/tests/test_options/test_match_relative_path.py
+++ b/tests/test_options/test_match_relative_path.py
@@ -1,0 +1,88 @@
+import os
+
+from tests.utils import create_file, run_rmlint, get_testdir
+
+
+def search_paths(*roots):
+    return ' '.join(os.path.join(get_testdir(), root) for root in roots)
+
+
+def dupe_paths(data):
+    return {
+        os.path.relpath(entry['path'], get_testdir())
+        for entry in data
+        if entry['type'] == 'duplicate_file' and not entry['is_original']
+    }
+
+
+def test_different_depth():
+    create_file('xxx', 'a/path/file')
+    create_file('xxx', 'b/another/path/file')
+
+    _, *_, footer = run_rmlint(
+        '--match-relative-path ' + search_paths('a', 'b'), use_default_dir=False
+    )
+    assert footer['total_files'] == 2
+    assert footer['total_lint_size'] == 0
+    assert footer['duplicates'] == 0
+
+
+def test_passed_directly():
+    create_file('xxx', 'a')
+    create_file('xxx', 'b')
+
+    _, *_, footer = run_rmlint(
+        '--match-relative-path ' + search_paths('a', 'b'), use_default_dir=False
+        )
+    assert footer['total_files'] == 2
+    assert footer['total_lint_size'] == 0
+    assert footer['duplicates'] == 0
+
+
+def test_differs_by_basename_only():
+    create_file('xxx', 'one/identical/path/alpha.txt')
+    create_file('xxx', 'another/one/identical/path/beta.txt')
+
+    _, *_, footer = run_rmlint(
+        '--match-relative-path ' + search_paths('one', 'another/one'),
+        use_default_dir=False,
+    )
+    assert footer['total_files'] == 2
+    assert footer['total_lint_size'] == 0
+    assert footer['duplicates'] == 0
+
+def test_combined_with_match_basename():
+    create_file('xxx', 'a/path/file')
+    create_file('xxx', 'b/other/file')
+    create_file('xxx', 'b/path/file')
+
+    _, *data, footer = run_rmlint(
+        '-b --match-relative-path ' + search_paths('a', 'b'), use_default_dir=False
+    )
+    assert footer['total_files'] == 3
+    assert footer['duplicates'] == 1
+    assert dupe_paths(data) == {'b/path/file'}
+
+
+def test_case_insensitive_ascii():
+    create_file('xxx', 'a/path/File.eXt')
+    create_file('xxx', 'b/PaTh/file.ext')
+
+    _, *_, footer = run_rmlint(
+        '--match-relative-path --case-insensitive ' + search_paths('a', 'b'), use_default_dir=False
+    )
+    assert footer['total_files'] == 2
+    assert footer['total_lint_size'] == 3
+    assert footer['duplicates'] == 1
+
+
+def test_case_insensitive_non_ascii():
+    create_file('xxx', 'a/ПÄ/file')
+    create_file('xxx', 'b/пä/file')
+
+    _, *_, footer = run_rmlint(
+        '--match-relative-path --case-insensitive ' + search_paths('a', 'b'), use_default_dir=False
+    )
+    assert footer['total_files'] == 2
+    assert footer['total_lint_size'] == 0
+    assert footer['duplicates'] == 0


### PR DESCRIPTION
I've added `--match-relative-path` support for my own needs and seems there is an existing feature request for that: https://github.com/sahib/rmlint/issues/550.

In my case it was useful to only keep files that have been changed in different backup snapshots and keep files which have different relative paths (and different content than file with the same relative path in original copy) although the same content as some file in original copy.