### PR TITLE
docs: MacOS: install brew update

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -115,7 +115,7 @@ Here's a list of readily prepared commands for known operating systems:
 
   .. code-block:: bash
 
-      $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)".
+      $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
   With homebrew installed, execute:
 


### PR DESCRIPTION
## The one liner command has changed

this link does not exist any more (404 http)

> https://raw.githubusercontent.com/Homebrew/install/master/install

resource:

> https://github.com/Homebrew/install/tree/master#install-homebrew-on-macos-or-linux