### PR TITLE
scons: check *xattr functions with correct arguments

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -270,9 +270,14 @@ def check_posix_fadvise(context):
 def check_xattr(context):
     rc = 1
 
-    for func in ['getxattr', 'setxattr', 'removexattr', 'listxattr']:
+    for func, funcargs in (
+        ('getxattr', '"path", "name", 0, 0'),
+        ('setxattr', '"path", "name", 0, 0, 0'),
+        ('removexattr', '"path", "name"'),
+        ('listxattr', '"path", "name", 0'),
+    ):
         if tests.CheckFunc(
-            context, func,
+            context, func, funcargs=funcargs,
             header=
                 '#include <sys/types.h>'
                 '#include <sys/xattr.h>'
@@ -291,9 +296,14 @@ def check_xattr(context):
 def check_lxattr(context):
     rc = 1
 
-    for func in ['lgetxattr', 'lsetxattr', 'lremovexattr', 'llistxattr']:
+    for func, funcargs in (
+        ('lgetxattr', '"path", "name", 0, 0'),
+        ('lsetxattr', '"path", "name", 0, 0, 0'),
+        ('lremovexattr', '"path", "name"'),
+        ('llistxattr', '"path", "name", 0'),
+    ):
         if tests.CheckFunc(
-            context, func,
+            context, func, funcargs=funcargs,
             header=
                 '#include <sys/types.h>'
                 '#include <sys/xattr.h>'


### PR DESCRIPTION
`SCons.Conftest.CheckFunc(context, "lgetxattr", "#include <sys/types.h>\n#include <sys/xattr.h>")` will generate following C code:

```
#include <assert.h>
#include <sys/types.h>
#include <sys/xattr.h>

#if _MSC_VER && !__INTEL_COMPILER
    #pragma function(lgetxattr)
#endif

int main(void) {
#if defined (__stub_lgetxattr) || defined (__stub___lgetxattr)
   #error "lgetxattr has a GNU stub, cannot check"
#else
   lgetxattr();
#endif

     return 0;
}
```

This code snippet will fail to compile on armhf on Ubuntu 24.04 (noble):

```
$ gcc -o test test.c
test.c: In function ‘main’:
test.c:13:11: error: too few arguments to function ‘lgetxattr’
   13 | lgetxattr();
      | ^~~~~~~~~
In file included from test2.c:3:
/usr/include/arm-linux-gnueabihf/sys/xattr.h:67:16: note: declared here
   67 | extern ssize_t lgetxattr (const char *__path, const char *__name,
      | ^~~~~~~~~
```

So pass valid arguments to the *xttr functions.

**Note**: The `funcargs` parameter requires SCons >= 4.7.0!

Bug-Ubuntu: https://launchpad.net/bugs/2066970