### PR TITLE
SCons: avoid checks leftovers

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       RM_TS_DIR: "/tmp/rmlint-unit-testdir"
     steps:

--- a/SConstruct
+++ b/SConstruct
@@ -314,7 +314,7 @@ def check_c11(context):
 
     context.Message('Checking for -std=c11 support...')
     try:
-        cmd = 'echo "#if __STDC_VERSION__ < 201112L\n#error \"No C11 support!\"\n#endif" | {cc} -xc - -std=c11 -c'
+        cmd = 'echo "#if __STDC_VERSION__ < 201112L\n#error \"No C11 support!\"\n#endif" | {cc} -xc - -std=c11 -c -o /dev/null'
         subprocess.check_call(
             cmd.format(cc=conf.env['CC']),
             shell=True


### PR DESCRIPTION
Closes: #685

`echo "" | cc -xc - -c` generates a '-.o' leftover (gcc/clang).