### PR TITLE
ci: use ubuntu-22.04 to run tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       RM_TS_DIR: "/tmp/rmlint-unit-testdir"
     steps:


### PR DESCRIPTION
There have been some changes in ubuntu24 that make it incompatible with nose. This will be eventually fixed but for now it will be good to have the test suite running.