### PR TITLE
fix data-loss issue with replays w/o checksums

### DIFF
--- a/lib/checksum.c
+++ b/lib/checksum.c
@@ -991,6 +991,10 @@ gboolean rm_digest_equal(RmDigest *a, RmDigest *b) {
         return false;
     }
 
+    if(a->bytes == 0) {
+        return true; /* this non-sense is used in replays */
+    }
+
     if(a->type == RM_DIGEST_PARANOID) {
         RmParanoid *pa = a->state;
         RmParanoid *pb = b->state;

--- a/lib/replay.c
+++ b/lib/replay.c
@@ -834,7 +834,7 @@ bool rm_parrot_cage_load(RmParrotCage *cage, const char *json_path, bool is_pref
 
         rm_log_debug("[okay]\n");
 
-        if(file->digest != NULL && !rm_digest_equal(file->digest, last_digest)) {
+        if((!file->digest->bytes && file->is_original) || !rm_digest_equal(file->digest, last_digest)) {
             rm_digest_free(last_digest);
             last_digest = rm_digest_copy(file->digest);
             rm_parrot_cage_push_to_group(cage, &group, false);
@@ -873,6 +873,9 @@ static void rm_parrot_merge_identical_groups(RmParrotCage *cage) {
     for(GList *iter = cage->groups->head; iter; iter = iter->next) {
         GQueue *group = iter->data;
         RmFile *head_file = group->head->data;
+
+        if (!head_file->digest->bytes)
+            continue;
 
         GQueue *existing_group = g_hash_table_lookup(digest_to_group, head_file->digest);
 

--- a/tests/test_options/test_replay.py
+++ b/tests/test_options/test_replay.py
@@ -459,3 +459,26 @@ def test_replay_unpack_directories(usual_setup_usual_teardown):
     expected["part_of_directory"] = EXPECTED_WITH_TREEMERGE["part_of_directory"]
 
     assert data_by_type(data) == expected
+
+
+def test_replay_hardlink(usual_setup_usual_teardown):
+    create_file('xxx', 'file_one')
+    create_link('file_one', 'file_one_link')
+    create_file('yyyy', 'file_two')
+    create_link('file_two', 'file_two_link')
+
+    replay_path = os.path.join(TESTDIR_NAME, 'replay.json')
+
+    head, *data, footer = run_rmlint('-o json:{p}'.format(
+        p=replay_path
+    ))
+
+    assert len(data) == 4
+
+    head, *data, footer = run_rmlint('--replay {p}'.format(
+        p=replay_path
+    ))
+
+    assert len(data) == 4
+    assert footer['duplicates'] == 2
+    assert footer['duplicate_sets'] == 2


### PR DESCRIPTION
Closes: #672

See bug details in https://github.com/sahib/rmlint/issues/672#issuecomment-2692483380.

This is just a bugfix, but I feel we could fix a bit more, although I'm not sure if that wouldn't introduce a regression. I haven't checked all the consumers of `file->digest`.
 
In `replay.c` we do:
```c
    file->digest = rm_digest_new(RM_DIGEST_EXT, 0);
[...]
    /* Fake the checksum using RM_DIGEST_EXT */
    JsonNode *cksum_node = json_object_get_member(object, "checksum");
    if(cksum_node != NULL) {
        const char *cksum = json_object_get_string_member(object, "checksum");
        if(cksum != NULL) {
            rm_digest_update(file->digest, (unsigned char *)cksum, strlen(cksum));
        }
    }
```

I would do instead:

```c
    file->digest = NULL;
[...]
    /* Fake the checksum using RM_DIGEST_EXT */
    JsonNode *cksum_node = json_object_get_member(object, "checksum");
    if(cksum_node != NULL) {
        const char *cksum = json_object_get_string_member(object, "checksum");
        if(cksum != NULL) {
            file->digest = rm_digest_new(RM_DIGEST_EXT, 0);
            rm_digest_update(file->digest, (unsigned char *)cksum, strlen(cksum));
        }
    }
```
And reintroduce checks for `file->digest == NULL` ; that would avoid pointless allocations.
Another way to be safe would be to check for `file->inode` to confirm that they belong to the same group.
Are hardlinks the only situation when rmlint does not generate checksums ?

PS: @sahib if you still follow this repository, the bird theme is nice. It's a change from the overly formal naming in code of other projects :)