### PR TITLE
json: properly escape cwd and args

### DIFF
--- a/lib/formats/json.c
+++ b/lib/formats/json.c
@@ -191,9 +191,9 @@ static void rm_fmt_head(RmSession *session, _UNUSED RmFmtHandler *parent, FILE *
         {
             rm_fmt_json_key(out, "description", "rmlint json-dump of lint files");
             rm_fmt_json_sep(self, out);
-            rm_fmt_json_key(out, "cwd", session->cfg->iwd);
+            rm_fmt_json_key_unsafe(out, "cwd", session->cfg->iwd);
             rm_fmt_json_sep(self, out);
-            rm_fmt_json_key(out, "args", session->cfg->joined_argv);
+            rm_fmt_json_key_unsafe(out, "args", session->cfg->joined_argv);
             rm_fmt_json_sep(self, out);
             rm_fmt_json_key(out, "version", RM_VERSION);
             rm_fmt_json_sep(self, out);


### PR DESCRIPTION
as they may contain any char but \0.

Closes: #682