### PR TITLE
Skip build test for non essentials #690

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,27 +14,45 @@ jobs:
       RM_TS_DIR: "/tmp/rmlint-unit-testdir"
     steps:
       - uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
+
+      - name: "Check changes"
+        # TODO also include skipping build but allow docs to be processed
+        run: |
+          if git diff --exit-code --name-only origin/master . ':!.gitignore' ':!docs' ':!*.md' ':!*.txt' ':!*.yml'; then
+            echo "SKIP_CHANGES=false" >> "$GITHUB_ENV"
+          else
+            echo "SKIP_CHANGES=true" >> "$GITHUB_ENV"
+          fi
+  
       - name: "Prepare build environment"
         run: |
-          sudo apt update
-          sudo apt install -y --no-install-recommends \
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
             scons python3-sphinx gettext python3-setuptools \
             libblkid-dev libelf-dev libglib2.0-dev libjson-glib-dev \
             clang python3-pip python3-cffi python3-dev libffi-dev
           pip3 install -r tests/requirements.txt
+          
       - name: "Build"
         # Todo: eventually run tests with valgrind (RM_TS_USE_VALGRIND)
         # Todo enable slow tests in pytest
         run: |
           scons config
           scons VERBOSE=1 DEBUG=1 O=release
+
       - name: "Prepare test environment"
+        # TODO Ignore linter warning. See https://github.com/github/vscode-github-actions/issues/222
+        if: ${{ env.SKIP_CHANGES == 'true' }}
         # The test suite is seriously disk-intensive. Given that linux
         #  instances hosted in GitHub have 16G of RAM available we will
         #  use it to speed up the run.
         run: |
           sudo mkdir "${RM_TS_DIR}"
           sudo mount -o size=12G,nr_inodes=0 -t tmpfs tmpfs "${RM_TS_DIR}"
-      - name: "Test"
+
+      - name: "Test it"
+        if: ${{ env.SKIP_CHANGES == 'true' }}
         run: |
           RM_TS_PRINT_CMD=1 RM_TS_PEDANTIC=0 python -m pytest -s -v


### PR DESCRIPTION
Skip the build test step when no executable changes are made.
This will speed up the process when only documents and such are modified. Save on quota too.

This can be improved to more fine grained step, when so desired:
* skip full build and test when only specific files are changed (global readme for instance)
* skip build and test but create man pages
* skip only test <this PR>

Adresses #690