### PR TITLE
various C linting

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -657,7 +657,7 @@ else:
 # check _mm_crc32_u64 (SSE4.2) support:
 conf.check_mm_crc32_u64()
 
-if 'clang' in os.path.basename(conf.env['CC']):
+if any(cc in os.path.basename(conf.env['CC']) for cc in ('clang', 'include-what-you-use')):
     conf.env.Append(CCFLAGS=['-fcolor-diagnostics'])  # Colored warnings
     conf.env.Append(CCFLAGS=['-Qunused-arguments'])   # Hide wrong messages
     conf.env.Append(CCFLAGS=['-Wno-bad-function-cast'])

--- a/lib/checksum.c
+++ b/lib/checksum.c
@@ -1009,7 +1009,6 @@ gboolean rm_digest_equal(RmDigest *a, RmDigest *b) {
         /* all the "easy" ways failed... do manual check of all buffers */
         GSList *a_iter = pa->buffers;
         GSList *b_iter = pb->buffers;
-        guint bytes = 0;
         while(a_iter && b_iter) {
             if(!rm_buffer_equal(a_iter->data, b_iter->data)) {
                 rm_log_error_line(
@@ -1017,7 +1016,6 @@ gboolean rm_digest_equal(RmDigest *a, RmDigest *b) {
                     "shadow hash");
                 return false;
             }
-            bytes += ((RmBuffer *)a_iter->data)->len;
             a_iter = a_iter->next;
             b_iter = b_iter->next;
         }

--- a/lib/checksums/highwayhash.c
+++ b/lib/checksums/highwayhash.c
@@ -117,7 +117,7 @@ static void Permute(const uint64_t v[4], uint64_t* permuted) {
     permuted[3] = (v[1] >> 32) | (v[1] << 32);
 }
 
-void PermuteAndUpdate(HighwayHashState* state) {
+static void PermuteAndUpdate(HighwayHashState* state) {
     uint64_t permuted[4];
     Permute(state->v0, permuted);
     Update(permuted, state);

--- a/lib/checksums/murmur3.c
+++ b/lib/checksums/murmur3.c
@@ -134,7 +134,7 @@ static inline uint64_t fmix64(uint64_t k) {
 
 //-----------------------------------------------------------------------------
 
-MurmurHash3_x86_32_state *MurmurHash3_x86_32_new() {
+MurmurHash3_x86_32_state *MurmurHash3_x86_32_new(void) {
     return g_slice_new0(MurmurHash3_x86_32_state);
 }
 

--- a/lib/hash-utility.c
+++ b/lib/hash-utility.c
@@ -28,9 +28,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "../lib/config.h"
-#include "../lib/hasher.h"
-#include "../lib/utilities.h"
+#include "config.h"
+#include "hasher.h"
+#include "utilities.h"
+#include "hash-utility.h"
 
 typedef struct RmHasherSession {
     /* Internal */

--- a/lib/pathtricia.c
+++ b/lib/pathtricia.c
@@ -97,18 +97,21 @@ typedef struct RmPathIter {
     char path_buf[PATH_MAX];
 } RmPathIter;
 
-void rm_path_iter_init(RmPathIter *iter, const char *path) {
+static void rm_path_iter_init(RmPathIter *iter, const char *path) {
     if(*path == '/') {
         path++;
     }
 
-    memset(iter->path_buf, 0, PATH_MAX);
     strncpy(iter->path_buf, path, PATH_MAX);
+    if (iter->path_buf[PATH_MAX - 1]) {
+        iter->path_buf[PATH_MAX - 1] = 0;
+        rm_log_error("path too long, truncated to: %s", iter->path_buf);
+    }
 
     iter->curr_elem = iter->path_buf;
 }
 
-char *rm_path_iter_next(RmPathIter *iter) {
+static char *rm_path_iter_next(RmPathIter *iter) {
     char *elem_begin = iter->curr_elem;
 
     if(elem_begin && (iter->curr_elem = strchr(elem_begin, '/'))) {

--- a/lib/pathtricia.h
+++ b/lib/pathtricia.h
@@ -28,6 +28,7 @@
 
 #include <glib.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 typedef struct _RmNode {
     /* Element of the path */

--- a/lib/replay.c
+++ b/lib/replay.c
@@ -152,7 +152,7 @@ static RmParrot *rm_parrot_open(RmSession *session, const char *json_path, bool 
     rm_trie_init(&polly->directory_trie);
 
     for(GSList *iter = session->cfg->paths; iter; iter = iter->next) {
-        RmPath *rmpath = iter->data;
+        const RmPath *rmpath = iter->data;
         RmStat stat_buf;
         if(rm_sys_stat(rmpath->path, &stat_buf) != -1) {
             g_hash_table_add(polly->disk_ids, GUINT_TO_POINTER(stat_buf.st_dev));
@@ -310,7 +310,7 @@ static RmFile *rm_parrot_try_next(RmParrot *polly) {
     }
 
     /* Fake the checksum using RM_DIGEST_EXT */
-    JsonNode *cksum_node = json_object_get_member(object, "checksum");
+    const JsonNode *cksum_node = json_object_get_member(object, "checksum");
     if(cksum_node != NULL) {
         const char *cksum = json_object_get_string_member(object, "checksum");
         if(cksum != NULL) {
@@ -319,7 +319,7 @@ static RmFile *rm_parrot_try_next(RmParrot *polly) {
     }
 
     /* Fix the hardlink relationship */
-    JsonNode *hardlink_of = json_object_get_member(object, "hardlink_of");
+    const JsonNode *hardlink_of = json_object_get_member(object, "hardlink_of");
     if(hardlink_of != NULL) {
         rm_file_hardlink_add(polly->last_original, file);
     } else {
@@ -426,11 +426,11 @@ static RmFile *rm_parrot_next(RmParrot *polly) {
 
 #define FAIL_MSG(msg) rm_log_debug(RED "[" msg "]\n" RESET)
 
-static bool rm_parrot_check_depth(RmCfg *cfg, RmFile *file) {
+static bool rm_parrot_check_depth(const RmCfg *cfg, const RmFile *file) {
     return (file->depth == 0 || file->depth <= cfg->depth);
 }
 
-static bool rm_parrot_check_size(RmCfg *cfg, RmFile *file) {
+static bool rm_parrot_check_size(const RmCfg *cfg, const RmFile *file) {
     if(cfg->limits_specified == false) {
         return true;
     }
@@ -451,7 +451,7 @@ static bool rm_parrot_check_size(RmCfg *cfg, RmFile *file) {
     return false;
 }
 
-static bool rm_parrot_check_hidden(RmCfg *cfg, _UNUSED RmFile *file,
+static bool rm_parrot_check_hidden(const RmCfg *cfg, _UNUSED RmFile *file,
                                    const char *file_path) {
     if(cfg->ignore_hidden == false && cfg->partial_hidden == false) {
         // no need to check.
@@ -507,7 +507,7 @@ static bool rm_parrot_check_path(RmParrot *polly, RmFile *file, const char *file
      */
 
     for(GSList *iter = cfg->paths; iter; iter = iter->next) {
-        RmPath *rmpath = iter->data;
+        const RmPath *rmpath = iter->data;
         size_t path_len = strlen(rmpath->path);
 
         if(strncmp(file_path, rmpath->path, path_len) == 0) {
@@ -527,7 +527,7 @@ static bool rm_parrot_check_path(RmParrot *polly, RmFile *file, const char *file
     return (highest_match > 0);
 }
 
-static bool rm_parrot_check_types(RmCfg *cfg, RmFile *file) {
+static bool rm_parrot_check_types(RmCfg *cfg, const RmFile *file) {
     switch(file->lint_type) {
     case RM_LINT_TYPE_DUPE_CANDIDATE:
         return cfg->find_duplicates;
@@ -623,7 +623,7 @@ static void rm_parrot_fix_duplicate_entries(RmParrotCage *cage, GQueue *group) {
 }
 
 static void rm_parrot_fix_must_match_tagged(RmParrotCage *cage, GQueue *group) {
-    RmCfg *cfg = cage->session->cfg;
+    const RmCfg *cfg = cage->session->cfg;
     if(!(cfg->must_match_tagged || cfg->must_match_untagged)) {
         return;
     }
@@ -631,7 +631,7 @@ static void rm_parrot_fix_must_match_tagged(RmParrotCage *cage, GQueue *group) {
     bool has_prefd = false, has_non_prefd = false;
 
     for(GList *iter = group->head; iter; iter = iter->next) {
-        RmFile *file = iter->data;
+        const RmFile *file = iter->data;
         if(file->lint_type != RM_LINT_TYPE_DUPE_CANDIDATE &&
            file->lint_type != RM_LINT_TYPE_DUPE_DIR_CANDIDATE) {
             // -k and -m only applies to dupes.
@@ -684,12 +684,12 @@ static void rm_parrot_update_stats(RmParrotCage *cage, RmFile *file) {
 }
 
 static void rm_parrot_cage_write_group(RmParrotCage *cage, GQueue *group, bool pack_directories) {
-    RmCfg *cfg = cage->session->cfg;
+    const RmCfg *cfg = cage->session->cfg;
 
     if(cfg->filter_mtime) {
         gsize older = 0;
         for(GList *iter = group->head; iter; iter = iter->next) {
-            RmFile *file = iter->data;
+            const RmFile *file = iter->data;
             older += (file->mtime >= cfg->min_mtime);
         }
 
@@ -877,7 +877,7 @@ static void rm_parrot_merge_identical_groups(RmParrotCage *cage) {
         GQueue *existing_group = g_hash_table_lookup(digest_to_group, head_file->digest);
 
         if(existing_group != NULL) {
-            RmFile *existing_head_file = existing_group->head->data;
+            const RmFile *existing_head_file = existing_group->head->data;
 
             /* Merge only groups with the same type */
             if(existing_head_file->lint_type == head_file->lint_type) {
@@ -914,7 +914,7 @@ void rm_parrot_cage_flush(RmParrotCage *cage) {
      * If so, we need to merge them up again using treemerge.c
      */
     for(GList *iter = cage->parrots->head; iter; iter = iter->next) {
-        RmParrot *parrot = iter->data;
+        const RmParrot *parrot = iter->data;
         if(parrot->pack_directories) {
             pack_directories = true;
             break;

--- a/lib/xattr.c
+++ b/lib/xattr.c
@@ -27,6 +27,7 @@
 #include "config.h"
 
 #include <errno.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
 


### PR DESCRIPTION
- add a check for a truncated path (PATH_MAX is indicative only, the real maximum length of a path is file-system dependent)
- remove an unused variable
- add some static and const
- simplify header path
- add IWYU to scons