### PR TITLE
tests: pin deps to current major version

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
-xattr==0.9.6
-psutil==5.6.6
-pytest==8.3.5
+psutil==7.*
+xattr==1.*
+pytest==8.*


### PR DESCRIPTION
It works well on develop without pinning at all (the day tests break, we check if that something on our side or an incompatibility from those packages).
On master, a bit more conservative strategy is to pin to major version number, that should guarantee no incompatible API changes. 