### PR TITLE
fix 32-bit compilation on old Glib

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -613,7 +613,7 @@ conf.env['HAVE_GLIB'] = 0
 conf.check_pkg('glib-2.0 >= 2.32', 'HAVE_GLIB', required=True)
 conf.env.Append(CCFLAGS=[
     '-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_32',
-    '-DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_64',
+    '-DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_32',
 ])
 
 conf.env['HAVE_GIO_UNIX'] = 0


### PR DESCRIPTION
The 64-bit released version of rmlint **already** uses [G_SIZEOF_MEMBER](https://docs.gtk.org/glib/func.SIZEOF_MEMBER.html), that is available on 2.64. So in practice, rmlint 2.10.2 has already 2.64 as a minimum version.
However, the 32-bit code does not use this macro, so it still compiles under older Glib on 32-bit. Let's not break user compatibility for 2.10.

This will be properly fixed in 2.11.