### PR TITLE
Use proper paths for shell calls

### DIFF
--- a/tests/test_formatters/test_sh.py
+++ b/tests/test_formatters/test_sh.py
@@ -7,10 +7,12 @@ import pytest
 
 
 def run_shell_script(shell, sh_path, *args):
-    return subprocess.check_output([
-            os.path.join("/bin", shell),
-            sh_path,
-        ] + list(args),
+    shell_path = shutil.which(shell)
+    if shell_path is None:
+        raise RuntimeError(f"{shell} not found in path")
+
+    return subprocess.check_output(
+        [shell_path, sh_path] + list(args),
         shell=False
     ).decode("utf-8")
 


### PR DESCRIPTION
Local shell paths vary by distribution, this aims to make tests work as long as the needed shells are on the $PATH. 

It should fix some of the issues in #713 and #593. 