### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ The format follows [keepachangelog.com]. Please stick to it.
 * issue #438: fix 'Can't open directory or file "...": Invalid argument' on some platforms
 * issue #621: fix GUI freeze with glib 2.75.3 and above
 * issue #608: fix setuptools InvalidVersion error when installing GUI with packaging 22.0 and above
-* issue #613: actually remove the GUI's Polkit requrement ('Namespace Polkit not available')
+* issue #613: actually remove the GUI's Polkit requirement ('Namespace Polkit not available')
 * issue #522: fix --size overflow detection on some platforms
 * issue #549: fix 'assertion failed: (node-\>inode != RM\_NO\_INODE)' on 32-bit platforms
 * issue #555: fix deadlock when `-T nonstripped` encountered an executable FIFO

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -78,7 +78,7 @@ Here's a list of readily prepared commands for known operating systems:
     $ sudo pacman -S python-sphinx python-sphinx-bootstrap-theme
     # Optional dependencies for the GUI:
     $ sudo pacman -S python-setuptools python-gobject python-cairo gtksourceview4 librsvg
-    # Optional dependancies for tests:
+    # Optional dependencies for tests:
     $ sudo pacman -S python-pytest python-xattr python-psutil btrfs-progs
 
   There is also git packages in AUR, from the ``master`` branch: `rmlint-git`_, `rmlint-shredder-git`_ ; and the ``develop`` branch: `rmlint-develop-git`_, `rmlint-shredder-develop-git`_.
@@ -110,7 +110,7 @@ Here's a list of readily prepared commands for known operating systems:
     $ sudo apt install python3-sphinx python3-sphinx-bootstrap-theme
     # Optional dependencies for the GUI:
     $ sudo apt install python3-setuptools python3-gi-cairo gir1.2-gtksource-4 gir1.2-polkit-1.0 gir1.2-rsvg-2.0 python3-colorlog
-    # Optional dependancies for tests:
+    # Optional dependencies for tests:
     $ sudo apt install python3-pytest python3-psutil python3-xattr
 
 .. _Debian: https://packages.debian.org/rmlint

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -573,7 +573,7 @@ as possible! Good practice includes adding a ``$`` anchor at the end of the rege
 
     # Sort paths with ABC in them first, then DEF, then GHI.
     # Everything with »temp«, »tmp« or »cache« in it comes last,
-    # the rest is sandwhiched in between and sorted by their modification time (m).
+    # the rest is sandwiched in between and sorted by their modification time (m).
     # If something is tied, the modification time is also used a sorting criteria.
     $ rmlint -S 'r<.*ABC.*>r<.*DEF.*>r<.*GHI.*>R<.*(tmp|temp|cache).*>m' /tmp/t
 

--- a/gui/shredder/util.py
+++ b/gui/shredder/util.py
@@ -280,7 +280,7 @@ class View(Gtk.Grid):
         """Show an infobar with a text message in it.
 
         Note: Latest gtk version color the infobar always blue.
-              This is slightly retarted and basically makes
+              This is slightly restarted and basically makes
               the message_type parameter useless.
         """
         self.infobar.show(message, message_type)

--- a/gui/shredder/views/locations.py
+++ b/gui/shredder/views/locations.py
@@ -52,7 +52,7 @@ class DeferSizeLabel(Gtk.Bin):
         du_proc.communicate_utf8_async(None, None, self._du_finished)
 
     def _du_finished(self, du_proc, result):
-        """Called when the coreutil du finished running. Harvest results."""
+        """Called when the coreutils du finished running. Harvest results."""
         result, du_data, _ = du_proc.communicate_utf8_finish(result)
         if du_data:
             kbytes = int(''.join([num for num in du_data if num.isdigit()]))

--- a/tests/test_formatters/test_sh.py
+++ b/tests/test_formatters/test_sh.py
@@ -126,7 +126,7 @@ def test_anon_pipe(usual_setup_usual_teardown):
 
     data = run_rmlint(
         "-o sh:>(cat)",
-        force_no_pendantic=True,
+        force_no_pedantic=True,
         directly_return_output=True,
         use_shell=True
     )

--- a/tests/test_mains/test_is_reflink.py
+++ b/tests/test_mains/test_is_reflink.py
@@ -76,7 +76,7 @@ def test_symlink(usual_setup_usual_teardown):
     except AssertionError:
         pass  # expected failure
     else:
-        raise AssertionError('test was epxected to fail')
+        raise AssertionError('test was expected to fail')
 
 
 def _run_dd_urandom(outfile, blocksize, count, extra=''):

--- a/tests/test_options/test_cache.py
+++ b/tests/test_options/test_cache.py
@@ -171,11 +171,11 @@ def test_clamp_xattr_false_negative(usual_setup_usual_teardown, clamp):
     create_file('xxx', 'c')
 
     # the first run after creating 'c' is ok...
-    head, *data, foot = run_rmlint('--xattr', force_no_pendantic=True)
+    head, *data, foot = run_rmlint('--xattr', force_no_pedantic=True)
     assert len([e for e in data if e['type'] == 'duplicate_file']) == 2  # 'a' matches 'c'
 
     # but we would get a false negative here, as the xattrs didn't match
-    head, *data, foot = run_rmlint('--xattr', force_no_pendantic=True)
+    head, *data, foot = run_rmlint('--xattr', force_no_pedantic=True)
     assert len([e for e in data if e['type'] == 'duplicate_file']) == 2  # do they still match?
 
 
@@ -194,9 +194,9 @@ def test_clamp_xattr_false_positive(usual_setup_usual_teardown, clamp):
     assert len([e for e in data if e['type'] == 'duplicate_file']) == 2  # '1' matches 'a/1'
 
     # fill in other xattrs
-    head, *data, foot = run_rmlint('--xattr', force_no_pendantic=True)
+    head, *data, foot = run_rmlint('--xattr', force_no_pedantic=True)
     assert len([e for e in data if e['type'] == 'duplicate_file']) == 4  # '1' matches 'a/1', '2' matches 'b/2'
 
     # we would get a false positive here, as the xattrs matched
-    head, *data, foot = run_rmlint('--xattr -T dd', force_no_pendantic=True)
+    head, *data, foot = run_rmlint('--xattr -T dd', force_no_pedantic=True)
     assert not any(e['type'] == 'duplicate_dir' for e in data)  # do 'a' and 'b' match?

--- a/tests/test_options/test_merge_directories.py
+++ b/tests/test_options/test_merge_directories.py
@@ -25,7 +25,7 @@ def test_simple(usual_setup_usual_teardown, extra_opts):
     assert 1 == sum(find['type'] == 'duplicate_file' for find in data if not find['is_original'])
     assert data[0]['size'] == 3
 
-    # -S A should sort in reverse lexigraphic order.
+    # -S A should sort in reverse lexicographic order.
     assert data[0]['is_original']
     assert not data[1]['is_original']
     assert data[0]['path'].endswith('2')
@@ -43,7 +43,7 @@ def test_diff(usual_setup_usual_teardown):
     assert 2 == sum(find['type'] == 'duplicate_dir' for find in data)
     assert data[0]['size'] == 3
 
-    # -S A should sort in reverse lexigraphic order.
+    # -S A should sort in reverse lexicographic order.
     assert data[0]['is_original']
     assert not data[1]['is_original']
     assert data[0]['path'].endswith('2')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -204,7 +204,7 @@ def compare_json_doc(doc_a, doc_b, compare_checksum=False):
         'disk_id', 'inode', 'mtime', 'path', 'size', 'type'
     ]
 
-    if compare_checksum and 'checkum' in doc_a and 'checksum' in doc_b:
+    if compare_checksum and 'checksum' in doc_a and 'checksum' in doc_b:
         keys.append('checksum')
 
     for key in keys:
@@ -305,8 +305,8 @@ def run_rmlint_pedantic(*args, **kwargs):
     return data
 
 
-def run_rmlint(*args, force_no_pendantic=False, **kwargs):
-    if get_env_flag('RM_TS_PEDANTIC') and force_no_pendantic is False:
+def run_rmlint(*args, force_no_pedantic=False, **kwargs):
+    if get_env_flag('RM_TS_PEDANTIC') and force_no_pedantic is False:
         return run_rmlint_pedantic(*args, **kwargs)
     else:
         return run_rmlint_once(*args, **kwargs)


### PR DESCRIPTION
Found via `codespell -S po -L pidgeon,splitted,ahd,collet,afile` and `typos --hidden --format brief`