### PR TITLE
treewide: cleanup, const-correctness, and `-Werror`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -167,12 +167,6 @@ conf.check_pkgconfig('0.15.0')
 conf.env['HAVE_GLIB'] = 0
 conf.check_pkg('glib-2.0 >= 2.64', 'HAVE_GLIB', required=True)
 
-if ARGUMENTS.get('VERBOSE') != "1":
-    conf.env.Append(CCFLAGS=[
-        '-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_64',
-        '-DGLIB_VERSION_MAX_REQUIRED=GLIB_VERSION_2_64',
-    ])
-
 conf.env['HAVE_GIO_UNIX'] = 0
 conf.check_pkg('gio-unix-2.0', 'HAVE_GIO_UNIX', required=False)
 
@@ -206,20 +200,33 @@ conf.check_mm_crc32_u64()
 if IS_CLANG := conf.CheckDeclaration("__clang__"):
     conf.env.Append(CCFLAGS=['-fcolor-diagnostics'])  # Colored warnings
     conf.env.Append(CCFLAGS=['-Qunused-arguments'])   # Hide wrong messages
-    conf.env.Append(CCFLAGS=['-Wno-bad-function-cast'])
+    conf.env.Append(CCFLAGS=[
+        '-Wmost',
+        '-Wunreachable-code-aggressive',
+        '-Wno-bad-function-cast',
+    ])
 else:
+    conf.env.Append(CCFLAGS=[
+        '-Wduplicated-cond',
+        '-Wduplicated-branches',
+        '-Wlogical-op',
+    ])
     conf.env.Append(CCFLAGS=['-Wno-cast-function-type'])
 
 # Optional flags:
 conf.env.Append(CCFLAGS=[
-    '-Wall', '-W', '-Wextra',
+    '-Wall', '-Wextra',
     '-Winit-self',
-    '-Wstrict-aliasing',
     '-Wmissing-include-dirs',
     '-Wuninitialized',
     '-Wstrict-prototypes',
+    '-Wnull-dereference',
+    '-Wformat-security',
+    '-Wformat-y2k',
+    '-Wmissing-noreturn',
     '-Wno-implicit-fallthrough',
     '-Wdeprecated-declarations',
+    '-Wundef',
 ])
 
 
@@ -250,8 +257,17 @@ if conf.env['HAVE_LIBELF']:
     conf.env.Append(_LIBFLAGS=['-lelf'])
 
 # NB: After checks so they don't fail
-conf.env.Append(CCFLAGS=['-Werror=undef'])
+if ARGUMENTS.get('FORCE') != '1':
+    conf.env.Append(CCFLAGS=['-Werror'])
 
+# XXX: after -Werror
+if ARGUMENTS.get('VERBOSE') != '1':
+    conf.env.Append(CCFLAGS=[
+        '-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_64',
+        '-DGLIB_VERSION_MAX_REQUIRED=GLIB_VERSION_2_64',
+    ])
+else:
+    conf.env.Append(CCFLAGS=['-Wno-error=deprecated-declarations'])
 
 if ARGUMENTS.get('GDB') == '1':
     ARGUMENTS['DEBUG'] = '1'

--- a/lib/checksum.c
+++ b/lib/checksum.c
@@ -170,13 +170,22 @@ static void rm_digest_xxhash_steal(gpointer state, guint8 *result) {
     *(unsigned long long *)result = XXH64_digest(state);
 }
 
+static void rm_digest_xxhash_free(gpointer state) {
+    XXH64_freeState(state);
+}
+
+static void rm_digest_xxhash_update(gpointer state, const unsigned char *data,
+                                    size_t size) {
+    XXH64_update(state, data, size);
+}
+
 static const RmDigestInterface xxhash_interface = {
     .name = "xxhash",
     .bits = 64,
     .len = NULL,
     .new = (RmDigestNewFunc)rm_digest_xxhash_new,
-    .free = (RmDigestFreeFunc)XXH64_freeState,
-    .update = (RmDigestUpdateFunc)XXH64_update,
+    .free = rm_digest_xxhash_free,
+    .update = rm_digest_xxhash_update,
     .copy = (RmDigestCopyFunc)rm_digest_xxhash_copy,
     .steal = rm_digest_xxhash_steal};
 
@@ -438,7 +447,7 @@ static void rm_digest_glib_steal(GChecksum *state, guint8 *result, gsize *len) {
         .free = (RmDigestFreeFunc)g_checksum_free,       \
         .update = (RmDigestUpdateFunc)g_checksum_update, \
         .copy = (RmDigestCopyFunc)g_checksum_copy,       \
-        .steal = (RmDigestStealFunc)rm_digest_##NAME##_steal};
+        .steal = (RmDigestStealFunc)rm_digest_##NAME##_steal}
 
 /* md5 */
 static GChecksum *rm_digest_md5_new(void) {
@@ -575,15 +584,21 @@ RM_DIGEST_DEFINE_SHA3(512)
         rm_digest_##ALGO##_free(copy);                                          \
     }                                                                           \
                                                                                 \
+    static void rm_digest_##ALGO##_update(gpointer state,                       \
+                                          const unsigned char *data,            \
+                                          size_t size) {                        \
+        ALGO##_update(state, data, size);                                       \
+    }                                                                           \
+                                                                                \
     static const RmDigestInterface ALGO##_interface = {                         \
         .name = #ALGO,                                                          \
         .bits = 8 * ALGO_BIG##_OUTBYTES,                                        \
         .len = NULL,                                                            \
         .new = (RmDigestNewFunc)rm_digest_##ALGO##_new,                         \
         .free = (RmDigestFreeFunc)rm_digest_##ALGO##_free,                      \
-        .update = (RmDigestUpdateFunc)ALGO##_update,                            \
+        .update = rm_digest_##ALGO##_update,                                    \
         .copy = (RmDigestCopyFunc)rm_digest_##ALGO##_copy,                      \
-        .steal = (RmDigestStealFunc)rm_digest_##ALGO##_steal};
+        .steal = (RmDigestStealFunc)rm_digest_##ALGO##_steal}
 
 CREATE_BLAKE2_INTERFACE(blake2b, BLAKE2B);
 CREATE_BLAKE2_INTERFACE(blake2bp, BLAKE2B);

--- a/lib/cmdline.c
+++ b/lib/cmdline.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <search.h>
 
+#include "config.h"
 #include "formats.h"
 #include "md-scheduler.h"
 #include "preprocess.h"
@@ -56,7 +57,7 @@ static const RmDigestType RM_PARANOIA_LEVELS[] = {RM_DIGEST_METRO,
 static const int RM_PARANOIA_NORMAL = 3;  /*  must be index of RM_DEFAULT_DIGEST */
 static const int RM_PARANOIA_MAX = 5;
 
-static void rm_cmd_show_version(void) {
+NORETURN static void rm_cmd_show_version(void) {
     fprintf(stderr, "version %s compiled: %s at [%s] \"%s\" (rev %s)\n", RM_VERSION,
             __DATE__, __TIME__, RM_VERSION_NAME, RM_VERSION_GIT_REVISION);
 
@@ -90,20 +91,19 @@ static void rm_cmd_show_version(void) {
     exit(0);
 }
 
-static void rm_cmd_show_manpage(void) {
-    static const char *commands[] = {"man %s docs/_build/man/rmlint.1 2> /dev/null",
-                                     "man %s rmlint", NULL};
+NORETURN static void rm_cmd_show_manpage(void) {
+    static const char *commands[] = {
+#ifdef RM_DEBUG
+        "man docs/_build/man/rmlint.1 2> /dev/null",
+#endif
+        "man rmlint",
+        NULL
+    };
 
     bool found_manpage = false;
 
     for(int i = 0; commands[i] && !found_manpage; ++i) {
-        char cmd_buf[512] = {0};
-        if(snprintf(cmd_buf, sizeof(cmd_buf), commands[i],
-                    (RM_MANPAGE_USE_PAGER) ? "" : "-P cat") == -1) {
-            continue;
-        }
-
-        if(system(cmd_buf) == 0) {
+        if(system(commands[i]) == 0) {
             found_manpage = true;
         }
     }
@@ -113,9 +113,10 @@ static void rm_cmd_show_manpage(void) {
         rm_log_warning_line(_("Please run rmlint --help to show the regular help."));
         rm_log_warning_line(_(
             "Alternatively, visit https://rmlint.rtfd.org for the online documentation"));
+        exit(EXIT_FAILURE);
     }
 
-    exit(0);
+    exit(EXIT_SUCCESS);
 }
 
 /* Size spec parsing implemented by qitta (http://github.com/qitta)
@@ -1495,7 +1496,7 @@ int rm_cmd_main(RmSession *session) {
     if(cfg->merge_directories) {
         rm_fmt_set_state(session->formats, RM_PROGRESS_STATE_MERGE);
         rm_tm_set_callback(session->dir_merger,
-                           (RmTreeMergeOutputFunc)rm_shred_output_tm_results, session);
+                           rm_shred_output_tm_results, session);
         rm_tm_finish(session->dir_merger);
     }
 

--- a/lib/config.h.in
+++ b/lib/config.h.in
@@ -34,8 +34,6 @@
 #define RM_VERSION_NAME  "{VERSION_NAME}"
 #define RM_VERSION_GIT_REVISION "{VERSION_GIT_REVISION}"
 
-#define RM_MANPAGE_USE_PAGER (1)
-
 /* Might come in useful */
 #define RM_CHECK_VERSION(X,Y,Z) (0  \
     || X <= RM_VERSION_MAJOR        \
@@ -132,6 +130,13 @@ typedef guint64 RmOff;
 #else
     /* give up */
     #define WARN_UNUSED_RESULT
+#endif
+
+#if __STDC_VERSION__ >= 202311L
+    #define NORETURN [[noreturn]]
+#else
+    #include <stdnoreturn.h>
+    #define NORETURN noreturn
 #endif
 
 #define _RM_OFFSET_DEBUG 0

--- a/lib/file.c
+++ b/lib/file.c
@@ -136,7 +136,10 @@ RmFile *rm_file_copy(RmFile *file) {
     return copy;
 }
 
-static gint rm_file_unref_impl(RmFile *file, gboolean unref_hardlinks) {
+static gint rm_file_unref_impl(gpointer file_ptr, gpointer unref_hardlinks_ptr) {
+    RmFile *file = file_ptr;
+    gboolean unref_hardlinks = GPOINTER_TO_INT(unref_hardlinks_ptr);
+
     if(!file) {
         return 0;
     }
@@ -149,8 +152,8 @@ static gint rm_file_unref_impl(RmFile *file, gboolean unref_hardlinks) {
     if(file->hardlinks) {
         g_queue_remove(file->hardlinks, file);
         if(unref_hardlinks) {
-            freed += rm_util_queue_foreach_remove(file->hardlinks,
-                        (RmRFunc)rm_file_unref_impl, GINT_TO_POINTER(FALSE));
+            freed += rm_util_queue_foreach_remove(file->hardlinks, rm_file_unref_impl,
+                                                  GINT_TO_POINTER(FALSE));
         }
         else if(file->hardlinks->length==0) {
             g_queue_free(file->hardlinks);
@@ -169,18 +172,27 @@ static gint rm_file_unref_impl(RmFile *file, gboolean unref_hardlinks) {
 }
 
 gint rm_file_unref(RmFile *file) {
-    return rm_file_unref_impl(file, FALSE);
+    return rm_file_unref_impl(file, GINT_TO_POINTER(FALSE));
 }
 
 gint rm_file_unref_full(RmFile *file) {
-    return rm_file_unref_impl(file, TRUE);
+    return rm_file_unref_impl(file, GINT_TO_POINTER(TRUE));
+}
+
+/* GDestroyNotify wrapper around rm_file_unref */
+void rm_file_unref_gdnotify(gpointer file) {
+    (void)rm_file_unref(file);
+}
+
+/* GFunc wrapper around rm_file_unref */
+void rm_file_unref_gfunc(gpointer file, _UNUSED gpointer user_data) {
+    (void)rm_file_unref(file);
 }
 
 RmFile *rm_file_ref(RmFile *file) {
     g_atomic_int_inc (&file->ref_count);
     return file;
 }
-
 
 // TODO: this is replicated in formats/pretty.c...
 static const char *LINT_TYPES[] = {
@@ -281,8 +293,11 @@ enum RmFileCountType {
     RM_FILE_COUNT_NEW,
 };
 
-static gint rm_file_count(RmFile *file, gint type) {
-    switch(type) {
+/* NOTE: must satisfy RmRFunc */
+static gint rm_file_count(gpointer file_gptr, gpointer type_gptr) {
+    RmFile *file = file_gptr;
+
+    switch(GPOINTER_TO_INT(type_gptr)) {
     case RM_FILE_COUNT_FILES:
         return 1;
     case RM_FILE_COUNT_PREFD:
@@ -298,21 +313,21 @@ static gint rm_file_count(RmFile *file, gint type) {
 }
 
 gint rm_file_n_files(RmFile *file) {
-    return rm_file_foreach(file, (RmRFunc)rm_file_count,
+    return rm_file_foreach(file, rm_file_count,
                            GINT_TO_POINTER(RM_FILE_COUNT_FILES));
 }
 
 gint rm_file_n_new(RmFile *file) {
-    return rm_file_foreach(file, (RmRFunc)rm_file_count,
+    return rm_file_foreach(file, rm_file_count,
                            GINT_TO_POINTER(RM_FILE_COUNT_NEW));
 }
 
 gint rm_file_n_prefd(RmFile *file) {
-    return rm_file_foreach(file, (RmRFunc)rm_file_count,
+    return rm_file_foreach(file, rm_file_count,
                            GINT_TO_POINTER(RM_FILE_COUNT_PREFD));
 }
 
 gint rm_file_n_nprefd(RmFile *file) {
-    return rm_file_foreach(file, (RmRFunc)rm_file_count,
+    return rm_file_foreach(file, rm_file_count,
                            GINT_TO_POINTER(RM_FILE_COUNT_NPREFD));
 }

--- a/lib/file.h
+++ b/lib/file.h
@@ -324,13 +324,23 @@ int rm_file_unref(RmFile *file);
  */
 int rm_file_unref_full(RmFile *file);
 
+/**
+ * @brief GDestroyNotify adapter for rm_file_unref().
+ */
+void rm_file_unref_gdnotify(gpointer file);
+
+/**
+ * @brief GFunc adapter for rm_file_unref().
+ * @note user_data is unused.
+ */
+void rm_file_unref_gfunc(gpointer file, gpointer user_data);
+
 
 /**
  * @brief Increase reference count to file;
  * @note threadsafe
  */
 RmFile *rm_file_ref(RmFile *file);
-
 
 
 /**

--- a/lib/formats/stats.c
+++ b/lib/formats/stats.c
@@ -96,7 +96,7 @@ static void rm_fmt_prog(RmSession *session,
     fprintf(out, _("%s%15ld%s Other lint items\n"), MAYBE_RED(out, session),
             (long)session->other_lint_cnt, MAYBE_RESET(out, session));
 
-    gfloat elapsed = g_timer_elapsed(session->timer_since_proc_start, NULL);
+    gdouble elapsed = g_timer_elapsed(session->timer_since_proc_start, NULL);
 
     char *elapsed_time = rm_format_elapsed_time(elapsed, 5);
     fprintf(out, _("%s%15s%s of time spent scanning\n"), MAYBE_RED(out, session),

--- a/lib/formats/summary.c
+++ b/lib/formats/summary.c
@@ -107,7 +107,7 @@ static void rm_fmt_prog(RmSession *session,
                       _("This run was a replay from a previous run. No I/O done!\n"));
     }
 
-    gfloat elapsed = g_timer_elapsed(session->timer_since_proc_start, NULL);
+    gdouble elapsed = g_timer_elapsed(session->timer_since_proc_start, NULL);
     char *elapsed_time = rm_format_elapsed_time(elapsed, 3);
     ARROW fprintf(out, _("Scanning took in total %s%s%s.\n"), MAYBE_RED(out, session),
                   elapsed_time, MAYBE_RESET(out, session));

--- a/lib/hasher.c
+++ b/lib/hasher.c
@@ -353,9 +353,9 @@ static void rm_hasher_hashpipe_free(GThreadPool *hashpipe) {
 }
 
 /* local joiner if user provides no joiner to rm_hasher_new() */
-static RmHasherCallback *rm_hasher_joiner(RmHasher *hasher, RmDigest *digest,
-                                          _UNUSED gpointer session_user_data,
-                                          _UNUSED gpointer task_user_data) {
+static int rm_hasher_joiner(RmHasher *hasher, RmDigest *digest,
+                            _UNUSED gpointer session_user_data,
+                            _UNUSED gpointer task_user_data) {
     g_async_queue_push(hasher->return_queue, digest);
     return 0;
 }
@@ -395,7 +395,7 @@ RmHasher *rm_hasher_new(RmDigestType digest_type,
     if(joiner) {
         self->callback = joiner;
     } else {
-        self->callback = (RmHasherCallback)rm_hasher_joiner;
+        self->callback = rm_hasher_joiner;
         self->return_queue = g_async_queue_new();
     }
 

--- a/lib/pathtricia.h
+++ b/lib/pathtricia.h
@@ -53,7 +53,7 @@ typedef struct _RmNode {
     ino_t inode;
 
     /* data was set explicitly */
-    char has_value : 1;
+    bool has_value : 1;
 
     /* User specific data */
     gpointer data;

--- a/lib/preprocess.c
+++ b/lib/preprocess.c
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <string.h>
 
+#include "file.h"
 #include "formats.h"
 #include "rank.h"
 
@@ -246,7 +247,7 @@ void rm_file_tables_destroy(RmFileTables *tables) {
     // walk along tables->size_groups, cleaning up as we go:
     while(tables->size_groups) {
         GSList *list = tables->size_groups->data;
-        g_slist_free_full(list, (GDestroyNotify)rm_file_unref);
+        g_slist_free_full(list, rm_file_unref_gdnotify);
         tables->size_groups =
                 g_slist_delete_link(tables->size_groups, tables->size_groups);
     }
@@ -295,7 +296,7 @@ void rm_preprocess(RmSession *session) {
     removed += rm_pp_bundle_hardlinks(session, all_files);
 
     /* sort into size groups, also sorting according to --match-basename etc */
-    g_queue_sort(all_files, (GCompareDataFunc)rm_rank_group, session);
+    g_queue_sort(all_files, rm_rank_group_gcmp, session);
 
     RmFile *prev = NULL, *curr = NULL;
     while((curr = g_queue_pop_head(all_files))) {

--- a/lib/rank.c
+++ b/lib/rank.c
@@ -245,7 +245,6 @@ int rm_rank_orig_criteria(const RmFile *a, const RmFile *b, const RmSession *ses
  * each other.  The sorted list can then be split into groups of potential
  * duplicates by splitting whereever rm_rank_group(a, b) != 0 */
 gint rm_rank_group(const RmFile *file_a, const RmFile *file_b) {
-
     RETURN_IF_NONZERO(SIGN_DIFF(file_a->actual_file_size, file_b->actual_file_size));
 
     /* --see-symlinks should not let regular files match symlinks */
@@ -258,8 +257,15 @@ gint rm_rank_group(const RmFile *file_a, const RmFile *file_b) {
     RETURN_IF_NONZERO(cfg->match_with_extension && rm_rank_with_extension(file_a, file_b));
 
     return cfg->match_without_extension && rm_rank_without_extension(file_a, file_b);
-
 }
+
+/* GCompareDataFunc wrapper around rm_rank_group */
+gint rm_rank_group_gcmp(gconstpointer file_a, gconstpointer file_b,
+                       _UNUSED gpointer user_data) {
+    return rm_rank_group(file_a, file_b);
+}
+
+
 
 gint rm_rank_basenames(const RmFile *file_a, const RmFile *file_b) {
     return g_ascii_strcasecmp(file_a->node->basename, file_b->node->basename);

--- a/lib/rank.h
+++ b/lib/rank.h
@@ -52,13 +52,15 @@ int rm_rank_orig_criteria(const RmFile *a, const RmFile *b, const RmSession *ses
 gint rm_rank_group(const RmFile *file_a, const RmFile *file_b);
 
 /**
+ * @brief: GCompareDataFunc adapter for rm_rank_group().
+ * @note user_data is unused.
+ */
+gint rm_rank_group_gcmp(gconstpointer file_a, gconstpointer file_b, gpointer user_data);
+
+/**
  * @brief: Compile all r<PATTERN> constructs in `sortcrit` to a GRegex
  *         and store them into session->pattern_cache.
  */
 char *rm_rank_compile_patterns(RmSession *session, const char *sortcrit, GError **error);
-
-
-
-
 
 #endif /* RM_RANK_H */

--- a/lib/reflink.c
+++ b/lib/reflink.c
@@ -167,6 +167,8 @@ RmLinkType rm_reflink_type_from_fd(int fd1, int fd2) {
 
     return RM_LINK_ERROR;
 #else /* HAVE_FIEMAP */
+    (void)fd1;
+    (void)fd2;
     return RM_LINK_NONE;
 #endif /* HAVE_FIEMAP */
 }
@@ -318,7 +320,7 @@ int rm_dedupe_main(int argc, const char **argv) {
                 rm_log_warning_line("dedupe: failed to preserve ownership for %s",
                                     source_path);
                 // try to preserve group ID
-                (void)lchown(cloneto_path, -1, source_stat.st_gid);
+                (void)!lchown(cloneto_path, -1, source_stat.st_gid);
             }
 
             if(lchmod(cloneto_path, source_stat.st_mode) != 0) {
@@ -510,11 +512,10 @@ int rm_is_reflink_main(int argc, const char **argv) {
     g_option_context_free(context);
     g_free(summary);
 
-    if(!HAVE_FIEMAP) {
-        rm_log_error_line(_("Cannot test for reflinks because rmlint was compiled without fiemap support"));
-        return EXIT_FAILURE;
-    }
-
+#if !HAVE_FIEMAP
+    rm_log_error_line(_("Cannot test for reflinks because rmlint was compiled without fiemap support"));
+    return EXIT_FAILURE;
+#else
     const char *a = argv[1];
     const char *b = argv[2];
 
@@ -535,4 +536,5 @@ int rm_is_reflink_main(int argc, const char **argv) {
     rm_log_info("Link type for '%s' and '%s', result:\n", a, b);
     rm_log_warning("%s\n", desc[result]);
     return result;
+#endif
 }

--- a/lib/shredder.c
+++ b/lib/shredder.c
@@ -831,7 +831,6 @@ static void rm_shred_group_finalise(RmShredGroup *self) {
         rm_util_thread_pool_push(self->session->shredder->result_pool, self);
         break;
     case RM_SHRED_GROUP_FINISHED:
-    default:
         g_assert_not_reached();
     }
 }
@@ -970,7 +969,6 @@ static RmFile *rm_shred_group_push_file(RmShredGroup *shred_group, RmFile *file,
             g_queue_push_head(shred_group->held_files, file);
             break;
         case RM_SHRED_GROUP_FINISHED:
-        default:
             g_assert_not_reached();
         }
     }
@@ -1050,10 +1048,10 @@ static RmFile *rm_shred_sift(RmFile *file) {
 }
 
 /* Hasher callback when file increment hashing is completed. */
-static void rm_shred_hash_callback(_UNUSED RmHasher *hasher,
-                                   RmDigest *digest,
-                                   _UNUSED RmShredTag *tag,
-                                   RmFile *file) {
+static int rm_shred_hash_callback(_UNUSED RmHasher *hasher,
+                                  RmDigest *digest,
+                                  _UNUSED RmShredTag *tag,
+                                  RmFile *file) {
     if(!file->digest) {
         file->digest = rm_digest_ref(digest);
     }
@@ -1067,6 +1065,8 @@ static void rm_shred_hash_callback(_UNUSED RmHasher *hasher,
         /* handle the file ourselves; MDS scheduler has moved on to the next file */
         rm_shred_sift(file);
     }
+
+    return 0;
 }
 
 ////////////////////////////////////
@@ -1735,11 +1735,12 @@ static gint rm_shred_process_file(RmFile *file, RmSession *session) {
 }
 
 /* called when treemerge.c found something interesting */
-void rm_shred_output_tm_results(RmFile *file, gpointer data) {
+gint rm_shred_output_tm_results(RmFile *file, gpointer data) {
     g_assert(data);
 
     RmSession *session = data;
     rm_fmt_write(file, session->formats);
+    return 0;
 }
 
 void rm_shred_run(RmSession *session) {

--- a/lib/shredder.h
+++ b/lib/shredder.h
@@ -72,6 +72,6 @@ void rm_shred_group_find_original(RmSession *session, GQueue *group,
  */
 int rm_shred_cmp_orig_criteria(RmFile *a, RmFile *b, RmSession *session);
 
-void rm_shred_output_tm_results(RmFile *result, gpointer data);
+gint rm_shred_output_tm_results(RmFile *result, gpointer data);
 
 #endif /* RM_SHREDDER_H */

--- a/lib/traverse.c
+++ b/lib/traverse.c
@@ -310,7 +310,6 @@ bool rm_traverse_is_emptydir(const char *path, RmCfg *cfg, int current_depth) {
             rm_log_warning_line(_("error %d in fts_read for %s (skipping)"), errno,
                                 p->fts_path);
             break;
-            break;
         case FTS_SLNONE:  /* symbolic link without target */
         case FTS_W:       /* whiteout object */
         case FTS_NS:      /* rm_sys_stat(2) failed */
@@ -339,7 +338,7 @@ bool rm_traverse_is_emptydir(const char *path, RmCfg *cfg, int current_depth) {
     memset(is_emptydir, 0, p->fts_level + 1); \
     memset(is_traversed, 0, p->fts_level + 1);
 
-static void rm_traverse_directory(RmTravBuffer *buffer, RmSession *session) {
+static gint rm_traverse_directory(RmTravBuffer *buffer, RmSession *session) {
     RmCfg *cfg = session->cfg;
     RmPath *rmpath = buffer->rmpath;
 
@@ -542,6 +541,8 @@ static void rm_traverse_directory(RmTravBuffer *buffer, RmSession *session) {
 done:
     rm_mds_device_ref(buffer->disk, -1);
     rm_trav_buffer_free(buffer);
+
+    return TRUE; /* task processed/succeeded for rm_mds_factory() */
 }
 
 ////////////////

--- a/lib/treemerge.c
+++ b/lib/treemerge.c
@@ -76,6 +76,7 @@
 #include <errno.h>
 #include <string.h>
 
+#include "file.h"
 #include "formats.h"
 #include "fts/fts.h"
 #include "rank.h"
@@ -341,7 +342,7 @@ static RmDirectory *rm_directory_new(char *dirname) {
 static void rm_directory_free(RmDirectory *self) {
     rm_digest_unref(self->digest);
     g_hash_table_unref(self->hash_set);
-    g_queue_foreach(&self->known_files, (GFunc)rm_file_unref, NULL);
+    g_queue_foreach(&self->known_files, rm_file_unref_gfunc, NULL);
     g_queue_clear(&self->known_files);
     g_queue_clear(&self->children);
     g_free(self->dirname);
@@ -395,17 +396,17 @@ static RmFile *rm_directory_as_new_file(RmTreeMerger *merger, const RmDirectory 
     return file;
 }
 
-static bool rm_directory_equal(RmDirectory *d1, RmDirectory *d2) {
+static gboolean rm_directory_equal(RmDirectory *d1, RmDirectory *d2) {
     if(d1->dupe_count != d2->dupe_count) {
-        return false;
+        return FALSE;
     }
 
-    if(rm_digest_equal(d1->digest, d2->digest) == false) {
-        return false;
+    if(rm_digest_equal(d1->digest, d2->digest) == FALSE) {
+        return FALSE;
     }
 
     if(g_hash_table_size(d1->hash_set) != g_hash_table_size(d2->hash_set)) {
-        return false;
+        return FALSE;
     }
 
     /* Compare the exact contents of the hash sets */
@@ -414,12 +415,12 @@ static bool rm_directory_equal(RmDirectory *d1, RmDirectory *d2) {
 
     g_hash_table_iter_init(&iter, d1->hash_set);
     while(g_hash_table_iter_next(&iter, &digest_key, NULL)) {
-        if(g_hash_table_contains(d2->hash_set, digest_key) == false) {
-            return false;
+        if(g_hash_table_contains(d2->hash_set, digest_key) == FALSE) {
+            return FALSE;
         }
     }
 
-    return true;
+    return TRUE;
 }
 
 static guint rm_directory_hash(const RmDirectory *d) {
@@ -914,7 +915,7 @@ static void rm_tm_extract(RmTreeMerger *self) {
         if(file_adaptor_group.length > 1) {
             rm_tm_output_group(self, &file_adaptor_group);
         }
-        g_queue_foreach(&file_adaptor_group, (GFunc)rm_file_unref, NULL);
+        g_queue_foreach(&file_adaptor_group, rm_file_unref_gfunc, NULL);
         g_queue_clear(&file_adaptor_group);
         g_queue_clear(&result_dirs);
     }

--- a/lib/utilities.c
+++ b/lib/utilities.c
@@ -1510,7 +1510,7 @@ bool rm_iso8601_format(time_t stamp, char *buf, gsize buf_size) {
 #define SECONDS_PER_HOUR (60 * 60)
 #define SECONDS_PER_MINUTE (60)
 
-char *rm_format_elapsed_time(gfloat elapsed_sec, int sec_precision) {
+char *rm_format_elapsed_time(gdouble elapsed_sec, int sec_precision) {
     GString *buf = g_string_new(NULL);
 
     if(elapsed_sec > SECONDS_PER_DAY) {

--- a/lib/utilities.h
+++ b/lib/utilities.h
@@ -470,7 +470,7 @@ bool rm_util_thread_pool_push(GThreadPool *pool, gpointer data);
  *
  * @return The formatted string, free with g_free.
  */
-char *rm_format_elapsed_time(gfloat elapsed_sec, int sec_precision);
+char *rm_format_elapsed_time(gdouble elapsed_sec, int sec_precision);
 
 typedef struct {
     gdouble sum;

--- a/lib/xattr.c
+++ b/lib/xattr.c
@@ -235,6 +235,9 @@ int rm_xattr_write_hash(RmFile *file, RmSession *session) {
        rm_xattr_set(file, mtime_key, timestamp, strlen(timestamp), follow)) {
         return errno;
     }
+#else
+    (void)file;
+    (void)session;
 #endif
     return 0;
 }
@@ -283,6 +286,8 @@ gboolean rm_xattr_read_hash(RmFile *file, RmSession *session) {
     file->ext_cksum = g_strdup(cksum_hex_str);
     return TRUE;
 #else /* HAVE_XATTR */
+    (void)file;
+    (void)session;
     return FALSE;
 #endif /* HAVE_XATTR */
 }
@@ -310,13 +315,15 @@ int rm_xattr_clear_hash(RmFile *file, RmSession *session) {
 
     return error;
 #else
+    (void)file;
+    (void)session;
     return EXIT_FAILURE;
 #endif
 }
 
 #if HAVE_XATTR
 
-GHashTable *rm_xattr_list(const char *path, bool follow_symlinks) {
+static GHashTable *rm_xattr_list(const char *path, bool follow_symlinks) {
     const size_t buf_size = 4096;
     const size_t val_size = 1024;
     const char prefix[13] = "user.rmlint.";
@@ -394,9 +401,12 @@ static void rm_xattr_change_subkey(char *key, char *sub_key) {
     strcpy(&key[key_len - sub_key_len], sub_key);
 }
 
+#endif
+
 bool rm_xattr_is_deduplicated(const char *path, bool follow_symlinks) {
     g_assert(path);
 
+#if HAVE_XATTR
     RmStat stat_buf;
     if(rm_sys_stat(path, &stat_buf) < 0) {
         rm_log_warning_line("failed to check dedupe state of %s: %s", path,
@@ -443,11 +453,17 @@ bool rm_xattr_is_deduplicated(const char *path, bool follow_symlinks) {
 
     g_hash_table_destroy(map);
     return result;
+#else
+    (void)path;
+    (void)follow_symlinks;
+    return false;
+#endif
 }
 
 int rm_xattr_mark_deduplicated(const char *path, bool follow_symlinks) {
     g_assert(path);
 
+#if HAVE_XATTR
     RmStat stat_buf;
     if(rm_sys_stat(path, &stat_buf) < 0) {
         rm_log_warning_line("failed to mark dedupe state of %s: %s", path,
@@ -488,6 +504,9 @@ int rm_xattr_mark_deduplicated(const char *path, bool follow_symlinks) {
 
     g_hash_table_destroy(map);
     return result;
-}
-
+#else /* HAVE_XATTR */
+    (void)path;
+    (void)follow_symlinks;
+    return EXIT_FAILURE;
 #endif /* HAVE_XATTR */
+}


### PR DESCRIPTION
- **utils: make string search functions const-correct**
  Usage of string search functions (`str*{chr,str}()`) in rmlint implicitly relies on const-laundering of its arguments. This is not the case anymore when building with glibc 2.41+ and C23 (which is the default on newer GCC), which surfaces a lot of annoying warnings.
  Constify all relevant places to avoid relying on implicit const-laundering.

- **pathtricia: use strlcpy(), get rid of -Wstringop-truncation warning**
  Complete the refactoring started in 5a0ad6cd and switch strncpy() to strlcpy() for better ergonomics and to squelch a `-Wstringop-truncation` warning.

- **-Werror, more warnings, and warning fixes**
  This is a patch lifted from @Cebtenzzre's tree (hopefully he won't object) with the rest of cleanups and `-Werror`.
