### PR TITLE
formats/py: fixes

### DIFF
--- a/lib/formats/py.py
+++ b/lib/formats/py.py
@@ -33,13 +33,12 @@ import argparse
 import filecmp
 import json
 import os
-import pwd
 import shutil
 import subprocess
 import sys
 
 CURRENT_UID = os.geteuid()
-CURRENT_GID = pwd.getpwuid(CURRENT_UID).pw_gid
+CURRENT_GID = os.getegid()
 
 USE_COLOR = sys.stdout.isatty() and sys.stderr.isatty()
 COLORS = {

--- a/lib/formats/py.py
+++ b/lib/formats/py.py
@@ -64,7 +64,7 @@ def original_check(path, original, be_paranoid=True):
                   '{o} <=> {p}'.format(c=COLORS, o=original, p=path))
             return False
 
-        if be_paranoid and not filecmp.cmp(path, original):
+        if be_paranoid and not filecmp.cmp(path, original, shallow=False):
             print('{c[red]}Content differs; ignoring:{c[reset]} '
                   '{o} <=> {p}'.format(c=COLORS, o=original, p=path))
             return False

--- a/lib/formats/py.py
+++ b/lib/formats/py.py
@@ -188,8 +188,10 @@ def main(args, data):
         sys.stdin.read(1)
 
     for item in data:
-        progress_prefix = '{c[blue]}[{p:3}%]{c[reset]} '.format(
-            c=COLORS, p=item['progress'])
+        progress_prefix = (
+            f"{COLORS['blue']}[{item['progress']:3}%]{COLORS['reset']} "
+            if 'progress' in item else ' ' * 7
+        )
 
         if item['is_original']:
             msg_template = MESSAGES.get(item['type'])

--- a/tests/test_formatters/test_py.py
+++ b/tests/test_formatters/test_py.py
@@ -21,6 +21,7 @@ def run_py_script(interpreter):
     ).decode('utf-8')
 
 
+# TODO: test for different Python3 versions
 @pytest.mark.parametrize("interpreter", ("python3",))
 def test_paranoia(interpreter):
     if not _check_interpreter(interpreter):
@@ -74,3 +75,26 @@ def test_paranoia(interpreter):
     assert footer['total_lint_size'] == 0
     assert footer['total_files'] == 4 # + 1
     assert footer['duplicates'] == 1
+
+
+@pytest.mark.parametrize("interpreter", ("python3",))
+def test_no_progress(interpreter):
+    """Check that the Python script doesn't chock on missing progress"""
+    if not _check_interpreter(interpreter):
+        pytest.skip(f"Interpreter {interpreter} does not seem to be working, skipping test")
+
+    create_file('', 'dir/empty_a')
+    create_file('', 'dir/empty_b')
+
+    _, *data, _ = run_rmlint(
+        f'-T "none +ef" -o py:{get_testdir()}/rmlint.py',
+        dir_suffix='dir', uses_py_formatter=True
+    )
+    assert len(data) == 2
+
+    # XXX: for now rmlint output per-file progress only
+    # for duplicates. We should not have any here.
+    assert not any('progress' in item for item in data)
+
+    # just check that the script does not chock on missing progress
+    assert 'Deleting empty file:' in run_py_script(interpreter)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -206,6 +206,7 @@ def run_rmlint_once(*args,
 
     cmd.extend(args_tokens)
 
+    # TODO: maybe use .rmlint.json if uses_py_formatter=True
     if with_json:
         cmd.extend(('-o', 'json:' + os.path.join(get_testdir(), 'out.json'), '-c', 'json:oneline'))
 
@@ -231,7 +232,7 @@ def run_rmlint_once(*args,
 
     if uses_py_formatter:
         # The py formatter writes its JSON document to `.rmlint.json` in
-        # rmlint's CWD and only once the traversal is over.If present from
+        # rmlint's CWD and only once the traversal is over. If present from
         # the previousrun remove it so it does not get in the way on this run.
         with contextlib.suppress(FileNotFoundError):
             os.unlink(os.path.join(get_testdir(), '.rmlint.json'))


### PR DESCRIPTION
filecmp.cmp() defaults to shallow=True, which returns True without reading a single byte if os.stat() signatures match.

Closes: #797