### PR TITLE
docs: fix RTFD EPUB build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -33,7 +33,7 @@ FROM alpine:3 AS run
 LABEL \
     org.opencontainers.image.title="rmlint" \
     org.opencontainers.image.source="https://github.com/sahib/rmlint" \
-    org.opencontainers.image.documentation="https://rmlint.readthedocs.io/" \
+    org.opencontainers.image.documentation="https://rmlint.rtfd.org/" \
     org.opencontainers.image.licenses="GPL-3.0-or-later"
 RUN apk add --no-cache glib json-glib libelf
 COPY --from=build /rmlint/rmlint /opt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,9 @@ html_theme_options = {
     'dark_css_variables': RMLINT_CSS,
 }
 
+# -- Options for misc formats output -------------------------------------------
+epub_exclude_files = ['_static/benchmarks/found_items.html']
+
 # -- Options for manual page output --------------------------------------------
 
 # One entry per manual page. List of tuples


### PR DESCRIPTION
Fix : https://app.readthedocs.org/projects/rmlint/builds/34375653/

We are using non-default fail_on_warning: true, so RTFD stopped the build.

`sphinx-build -b epub -d docs/_build/doctrees docs docs/_build/epub` works locally now.