### PR TITLE
docs: fix badges

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -42,6 +42,7 @@ jobs:
       - name: Build documentation
         run: |
           scons STRICT=1 docs
+          sphinx-build -T -W -b epub -d docs/_build/doctrees docs docs/_build/epub
 
       - name: Prepare test environment
         # The test suite is seriously disk-intensive. Given that linux

--- a/README.rst
+++ b/README.rst
@@ -10,20 +10,36 @@ offers to remove it.
 .. image:: https://img.shields.io/github/v/release/sahib/rmlint?include_prereleases&display_name=release
    :target: https://github.com/sahib/rmlint/releases
 
-.. image:: https://github.com/sahib/rmlint/actions/workflows/build-and-test.yml/badge.svg
-   :target: https://github.com/sahib/rmlint/actions
-
-.. image:: https://readthedocs.org/projects/rmlint/badge/?version=latest
-   :target: http://rmlint.rtfd.org
-
-.. image:: https://img.shields.io/github/issues/sahib/rmlint.svg?style=flat
-   :target: https://github.com/sahib/rmlint/issues
-
 .. image:: https://img.shields.io/github/commit-activity/m/sahib/rmlint/develop
    :target: https://github.com/sahib/rmlint/commits/develop/
 
-.. image:: http://img.shields.io/badge/license-GPLv3-4AC51C.svg?style=flat
-   :target: https://www.gnu.org/licenses/quick-guide-gplv3.html.en
+.. image:: https://img.shields.io/github/issues/sahib/rmlint.svg
+   :target: https://github.com/sahib/rmlint/issues
+
+.. image:: https://img.shields.io/github/issues-pr/sahib/rmlint.svg
+   :target: https://github.com/sahib/rmlint/pulls
+
+.. image:: https://img.shields.io/github/license/sahib/rmlint.svg
+   :target: https://www.gnu.org/licenses/quick-guide-gplv3.html
+
+   .. raw:: html
+
+      <br>
+
+.. image:: https://github.com/sahib/rmlint/actions/workflows/linux.yaml/badge.svg
+   :target: https://github.com/sahib/rmlint/actions/workflows/linux.yaml
+
+.. image:: https://github.com/sahib/rmlint/actions/workflows/freebsd.yaml/badge.svg
+   :target: https://github.com/sahib/rmlint/actions/workflows/freebsd.yaml
+
+.. image:: https://github.com/sahib/rmlint/actions/workflows/macos.yaml/badge.svg
+   :target: https://github.com/sahib/rmlint/actions/workflows/macos.yaml
+
+.. image:: https://github.com/sahib/rmlint/actions/workflows/cygwin.yaml/badge.svg
+   :target: https://github.com/sahib/rmlint/actions/workflows/cygwin.yaml
+
+.. image:: https://app.readthedocs.org/projects/rmlint/badge/
+   :target: https://rmlint.rtfd.org/
 
 **Features:**
 

--- a/docs/_badges.rst
+++ b/docs/_badges.rst
@@ -1,0 +1,43 @@
+.. raw:: html
+
+   <center>
+
+.. only:: builder_html
+
+   .. image:: https://img.shields.io/github/v/release/sahib/rmlint?include_prereleases&display_name=release
+      :target: https://github.com/sahib/rmlint/releases
+
+   .. image:: https://img.shields.io/github/commit-activity/m/sahib/rmlint/develop
+      :target: https://github.com/sahib/rmlint/commits/develop/
+
+   .. image:: https://img.shields.io/github/issues/sahib/rmlint.svg
+      :target: https://github.com/sahib/rmlint/issues
+
+   .. image:: https://img.shields.io/github/issues-pr/sahib/rmlint.svg
+      :target: https://github.com/sahib/rmlint/pulls
+
+   .. image:: https://img.shields.io/badge/license-GPLv3-4AC51C.svg
+      :target: https://www.gnu.org/licenses/quick-guide-gplv3.html
+
+   .. raw:: html
+
+      <br/>
+
+   .. image:: https://github.com/sahib/rmlint/actions/workflows/linux.yaml/badge.svg
+      :target: https://github.com/sahib/rmlint/actions/workflows/linux.yaml
+
+   .. image:: https://github.com/sahib/rmlint/actions/workflows/freebsd.yaml/badge.svg
+      :target: https://github.com/sahib/rmlint/actions/workflows/freebsd.yaml
+
+   .. image:: https://github.com/sahib/rmlint/actions/workflows/macos.yaml/badge.svg
+      :target: https://github.com/sahib/rmlint/actions/workflows/macos.yaml
+
+   .. image:: https://github.com/sahib/rmlint/actions/workflows/cygwin.yaml/badge.svg
+      :target: https://github.com/sahib/rmlint/actions/workflows/cygwin.yaml
+
+   .. image:: https://app.readthedocs.org/projects/rmlint/badge/
+      :target: https://rmlint.rtfd.org/
+
+.. raw:: html
+
+   </center>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,36 +37,7 @@ to remove it. It is able to find:
 
 ----
 
-.. .. image:: https://raw.githubusercontent.com/sahib/rmlint/develop/docs/_static/logo.png
-..    :align: left 
-..    :width: 150
-
-.. raw:: html
-
-    <center>
-
-.. image:: https://img.shields.io/github/v/release/sahib/rmlint?include_prereleases&display_name=release
-   :target: https://github.com/sahib/rmlint/releases
-
-.. image:: https://readthedocs.org/projects/rmlint/badge/?version=latest
-   :target: http://rmlint.rtfd.org
-
-.. image:: https://github.com/sahib/rmlint/actions/workflows/build-and-test.yml/badge.svg
-   :target: https://github.com/sahib/rmlint/actions
-
-.. image:: https://img.shields.io/github/issues/sahib/rmlint.svg?style=flat
-   :target: https://github.com/sahib/rmlint/issues
-
-.. image:: https://img.shields.io/github/commit-activity/m/sahib/rmlint/develop
-   :target: https://github.com/sahib/rmlint/commits/develop/
-
-.. image:: http://img.shields.io/badge/license-GPLv3-4AC51C.svg?style=flat
-   :target: https://www.gnu.org/licenses/quick-guide-gplv3.html.en
-
-
-.. raw:: html
-
-    </center>
+.. include:: _badges.rst
 
 User manual
 -----------
@@ -139,4 +110,3 @@ License
 ``rmlint`` is licensed under the terms of GPLv3_.
 
 .. _GPLv3: http://www.gnu.org/copyleft/gpl.htm
-


### PR DESCRIPTION
A broken badge image link made EPUB generation fails. Fix it and don't include badges into formats other than HTML.

Test EPUB in CI because RTFD doesn't do it for PRs (HTML only).

Put the badges into a separate file, so that packagers can easily remove it for privacy patches, like https://salsa.debian.org/debian/rmlint/-/blob/debian/master/debian/patches/privacy-breach-workaround.patch?ref_type=heads