### PR TITLE
i18n: honour TEXTDOMAINDIR on debug

### DIFF
--- a/src/rmlint.c
+++ b/src/rmlint.c
@@ -62,7 +62,13 @@ static void signal_handler(int signum) {
 static void i18n_init(void) {
 #if HAVE_LIBINTL
     /* Tell gettext where to search for .mo files */
+#ifdef RM_DEBUG
+    const char *locale_dir = getenv("TEXTDOMAINDIR");
+    bindtextdomain(RM_GETTEXT_PACKAGE,
+                   locale_dir ? locale_dir : INSTALL_PREFIX "/share/locale");
+#else
     bindtextdomain(RM_GETTEXT_PACKAGE, INSTALL_PREFIX "/share/locale");
+#endif
     bind_textdomain_codeset(RM_GETTEXT_PACKAGE, "UTF-8");
 
     /* Make printing umlauts work */


### PR DESCRIPTION
Test a translation:

```bash
$ mkdir -p locale/ka/LC_MESSAGES
$ msgfmt po/ka.po -o locale/ka/LC_MESSAGES/rmlint.mo
$ TEXTDOMAINDIR=locale LANG=ka_GE.UTF-8 LC_MESSAGE=ka_GE.UTF-8 ./rmlint --version
version 2.11.0-dev+g0491702a "Evolving Echidna"
built Sep  9 2026 at 16:12:17 UTC
აგებულია რით: +mounts +nonstripped +fiemap +intl +xattr +btrfs-support
[...]
```

You still need:
```bash
# sed -i '/ka_GE.UTF-8/s/^# //' /etc/locale.gen
# locale-gen
```
(or on Debian: `dpkg-reconfigure --frontend=noninteractive locales`)