### PR TITLE
treemerge: fix honouring directories layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format follows [keepachangelog.com]. Please stick to it.
 * FreeBSD: ``rmlint.sh``'s RMLINT_BINARY= entry.
 * Fix ``--honour-dir-layout``/``-j`` when filenames and content are the sames, just not
   at the same place.
+* Add a protection against ``-D`` XOR cancellation
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format follows [keepachangelog.com]. Please stick to it.
 * Fix GUI failing to start with pygobject >= 3.56
 * Make SSE4.2 runtime dispatch works on Clang builds.
 * FreeBSD: ``rmlint.sh``'s RMLINT_BINARY= entry.
+* Fix ``--honour-dir-layout``/``-j`` when filenames and content are the sames, just not
+  at the same place.
 
 ### Added
 

--- a/lib/treemerge.c
+++ b/lib/treemerge.c
@@ -508,10 +508,12 @@ static void rm_directory_add_subdir(RmTreeMerger *self, RmDirectory *parent,
 #endif
 
     /* Take over the child's digests */
-    for(GList *iter = subdir->known_files.head; iter; iter = iter->next) {
-        RmFile *file = iter->data;
-        g_hash_table_add(parent->hash_set, file->digest);
-    }
+    GHashTableIter digest_iter;
+    gpointer digest_key;
+
+    g_hash_table_iter_init(&digest_iter, subdir->hash_set);
+    while (g_hash_table_iter_next(&digest_iter, &digest_key, NULL))
+        g_hash_table_add(parent->hash_set, digest_key);
 
     /* Inherit the child's checksum */
     guint8 *subdir_cksum = rm_digest_steal(subdir->digest);

--- a/lib/treemerge.c
+++ b/lib/treemerge.c
@@ -433,6 +433,31 @@ static guint rm_directory_hash(const RmDirectory *d) {
     return rm_digest_hash(d->digest) ^ d->dupe_count;
 }
 
+/* Update directory digest with a combined hash of basename and
+ * its digest for -j to respect layout even with identical filenames
+ * in different places or with swapped content. */
+static void rm_directory_add_layout_entry(RmDirectory *directory, const char *name,
+                                          const guint8 *cksum, gsize cksum_bytes) {
+    /* basename and digest are \0-separated */
+    gsize name_len = strlen(name) + 1;
+    gsize buf_len = name_len + cksum_bytes;
+
+    guint8 *buf = g_slice_alloc(buf_len);
+    memcpy(buf, name, name_len);
+    memcpy(buf + name_len, cksum, cksum_bytes);
+
+    gsize entry_cksum_len = 0;
+    /* XXX: BLAKE2B is a good checksum for its size, but should we change it alongside
+     * the default checksum ? */
+    guint8 *entry_cksum =
+        rm_digest_sum(RM_DIGEST_BLAKE2B, buf, buf_len, &entry_cksum_len);
+
+    rm_digest_update(directory->digest, entry_cksum, entry_cksum_len);
+
+    g_slice_free1(entry_cksum_len, entry_cksum);
+    g_slice_free1(buf_len, buf);
+}
+
 static void rm_directory_add(RmTreeMerger *self, RmDirectory *directory, RmFile *file) {
     g_assert(file);
     g_assert(file->digest);
@@ -452,15 +477,8 @@ static void rm_directory_add(RmTreeMerger *self, RmDirectory *directory, RmFile 
 
     /* Add the path to the checksum if we require the same layout too */
     if(self->session->cfg->honour_dir_layout) {
-        const char *basename = file->node->basename;
-        gsize basename_cksum_len = 0;
-        guint8 *basename_cksum =
-            rm_digest_sum(RM_DIGEST_BLAKE2B,
-                          (const guint8 *)basename,
-                          strlen(basename) + 1, /* include the nul-byte */
-                          &basename_cksum_len);
-        rm_digest_update(directory->digest, basename_cksum, basename_cksum_len);
-        g_slice_free1(basename_cksum_len, basename_cksum);
+        rm_directory_add_layout_entry(directory, file->node->basename, file_digest,
+                                      digest_bytes);
     }
 
     g_slice_free1(digest_bytes, file_digest);
@@ -496,23 +514,16 @@ static void rm_directory_add_subdir(RmTreeMerger *self, RmDirectory *parent,
     }
 
     /* Inherit the child's checksum */
-    unsigned char *subdir_cksum = rm_digest_steal(subdir->digest);
+    guint8 *subdir_cksum = rm_digest_steal(subdir->digest);
     rm_digest_update(parent->digest, subdir_cksum, subdir->digest->bytes);
-    g_slice_free1(subdir->digest->bytes, subdir_cksum);
 
     if(self->session->cfg->honour_dir_layout) {
         char *basename = g_path_get_basename(subdir->dirname);
-        gsize basename_cksum_len = 0;
-        guint8 *basename_cksum =
-            rm_digest_sum(RM_DIGEST_BLAKE2B,
-                          (const guint8 *)basename,
-                          strlen(basename) + 1, /* include the nul-byte */
-                          &basename_cksum_len);
-
-        rm_digest_update(parent->digest, basename_cksum, basename_cksum_len);
-        g_slice_free1(basename_cksum_len, basename_cksum);
+        rm_directory_add_layout_entry(parent, basename, subdir_cksum, subdir->digest->bytes);
         g_free(basename);
     }
+
+    g_slice_free1(subdir->digest->bytes, subdir_cksum);
 
     subdir->was_merged = true;
 }

--- a/tests/test_options/test_merge_directories.py
+++ b/tests/test_options/test_merge_directories.py
@@ -507,3 +507,28 @@ def test_same_layout_with_swapped_content():
 
         for point in data:
             assert point["type"] == "duplicate_file"
+
+
+def test_xor_cancelling_content():
+    # tree-a and tree-c really hold the same data
+    # tree-b cancels out when content XORed with itself
+    for content, subdir in (('xxx', 'tree-a'), ('yyy', 'tree-b'), ('xxx', 'tree-c')):
+        create_file(content, subdir + '/some/path/x')
+        create_file(content, subdir + '/some/path/y')
+
+    _, *data, _ = run_rmlint('-p -D --rank-by a')
+    data = filter_part_of_directory(data)
+
+    dupe_dirs = [p for p in data if p['type'] == 'duplicate_dir']
+
+    assert len(dupe_dirs) == 2
+    assert dupe_dirs[0]['path'].endswith('tree-a')
+    assert dupe_dirs[0]['is_original'] is True
+    assert dupe_dirs[1]['path'].endswith('tree-c')
+    assert dupe_dirs[1]['is_original'] is False
+
+    # The dupes inside tree-b are still found
+    tree_b_dupes = [p for p in data if p['type'] != 'duplicate_dir']
+
+    assert all(p['type'] == 'duplicate_file' for p in tree_b_dupes)
+    assert 2 == sum('tree-b' in p['path'] for p in tree_b_dupes)

--- a/tests/test_options/test_merge_directories.py
+++ b/tests/test_options/test_merge_directories.py
@@ -20,6 +20,18 @@ def filter_part_of_directory(data):
     return data
 
 
+def pedantic_options():
+    # Test all checksum types, even outside of pedantic mode.
+    # That allows us to test for regressions in the cumulative digest,
+    # as digests of different lengths might have side-effects.
+    options = ['-p']
+    if not get_env_flag('pedantic'):
+        for cksum_type in CKSUM_TYPES:
+            options.append('--algorithm=' + cksum_type)
+
+    return options
+
+
 # --write-unfinished variant is a regression test for GitHub issue #562;
 # --hash-unmatched covers its successor
 @pytest.mark.parametrize('extra_opts', [(), ('--write-unfinished',), ('--hash-unmatched',)])
@@ -414,14 +426,7 @@ def test_equal_content_different_layout():
     create_file('xxx', "tree-b/x")
     create_file('yyy', "tree-b/y")
 
-    # Test all checksum types, even outside of pedantic mode.
-    # That allows us to test for regressions in the cumulative digest.
-    options = ['-p']
-    if not get_env_flag('pedantic'):
-        for cksum_type in CKSUM_TYPES:
-            options.append('--algorithm=' + cksum_type)
-
-    for option in options:
+    for option in pedantic_options():
         _, *data, _ = run_rmlint('-D --rank-by a', option)
         data = filter_part_of_directory(data)
 
@@ -452,3 +457,53 @@ def test_nested_content_with_same_layout():
     # just check if those are duplicate files as expected.
     for point in data[2:]:
         assert point["type"] == "duplicate_file"
+
+
+def test_same_content_and_filenames_nested_differently():
+    """Regression test for GitHub issue #742"""
+    create_file('yyy', "aa/bb/yy.txt")
+    create_file('xxx', "aa/xx.txt")
+
+    create_file('xxx', "cc/bb/xx.txt")
+    create_file('yyy', "cc/bb/yy.txt")
+
+    # same data, should mark directories as duplicates
+    _, *data, _ = run_rmlint('-p -D  --rank-by a')
+    data = filter_part_of_directory(data)
+
+    assert data[0]["path"].endswith("aa")
+    assert data[0]["type"] == "duplicate_dir"
+    assert data[1]["path"].endswith("cc")
+    assert data[1]["type"] == "duplicate_dir"
+
+    # different layout, should not mark directories as dupes
+    for option in pedantic_options():
+        _, *data, _ = run_rmlint('-Dj --rank-by a', option)
+        data = filter_part_of_directory(data)
+
+        for point in data:
+            assert point["type"] == "duplicate_file"
+
+
+def test_same_layout_with_swapped_content():
+    # Same names on both sides, but each name holds the other one's content.
+    create_file('xxx', "tree-a/x")
+    create_file('yyy', "tree-a/y")
+
+    create_file('yyy', "tree-b/x")
+    create_file('xxx', "tree-b/y")
+
+    _, *data, _ = run_rmlint('-p -D --rank-by a')
+    data = filter_part_of_directory(data)
+
+    assert data[0]["path"].endswith("tree-a")
+    assert data[0]["type"] == "duplicate_dir"
+    assert data[1]["path"].endswith("tree-b")
+    assert data[1]["type"] == "duplicate_dir"
+
+    for option in pedantic_options():
+        _, *data, _ = run_rmlint('-Dj --rank-by a', option)
+        data = filter_part_of_directory(data)
+
+        for point in data:
+            assert point["type"] == "duplicate_file"


### PR DESCRIPTION
It didn't record the association between filenames and their content, so a directory with swapped content but identical filenames or just identical filenames but at differents places was reported as a duplicate.

Closes: #742